### PR TITLE
インデントずれの解消

### DIFF
--- a/src/control-syntax.md
+++ b/src/control-syntax.md
@@ -391,8 +391,8 @@ val lst = List(List("A"), List("B", "C"))
 
 lst match {
   case List(a@List("A"), x) =>
-  println(a)
-  println(x)
+    println(a)
+    println(x)
   case _ => println("nothing")
 }
 ```


### PR DESCRIPTION
初めてのOSSへのCommitなので不手際ございましたらご了承ください。

https://scala-text.github.io/scala_text/control-syntax.html#%E3%83%91%E3%82%BF%E3%83%BC%E3%83%B3%E3%83%9E%E3%83%83%E3%83%81%E3%81%AB%E3%82%88%E3%82%8B%E5%80%A4%E3%81%AE%E5%8F%96%E3%82%8A%E5%87%BA%E3%81%97

こちら部分のインデントがズレていたので修正です。