### PR TITLE
トレイトのエラーの例(競合するメンバーの継承)を追加

### DIFF
--- a/src/trait.md
+++ b/src/trait.md
@@ -176,7 +176,13 @@ class ClassA extends TraitB with TraitC
 ちなみに、上記の例をScalaでコンパイルすると以下のようなエラーが出ます。
 
 ```scala
-class ClassA extends TraitB with TraitC
+scala> class ClassA extends TraitB with TraitC
+<console>:13: error: class ClassA inherits conflicting members:
+  method greet in trait TraitB of type ()Unit  and
+  method greet in trait TraitC of type ()Unit
+(Note: this can be resolved by declaring an override in class ClassA.)
+       class ClassA extends TraitB with TraitC
+             ^
 ```
 
 Scalaではoverride指定なしの場合メソッド定義の衝突はエラーになります。


### PR DESCRIPTION
[菱形継承問題](https://scala-text.github.io/scala_text/trait.html#%E8%8F%B1%E5%BD%A2%E7%B6%99%E6%89%BF%E5%95%8F%E9%A1%8C)でエラーの文面が掲載されていなかったので追記しました。


