### PR TITLE
CIで使用するNodeのバージョンが古く、動かなくなっているのを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - openjdk8
 before_install:
 - export CXX='g++-4.8'
-- nvm install 9.4.0 && nvm use 9.4.0 && npm install -g npm && npm install
+- nvm install 12.18.3 && nvm use 12.18.3 && npm install -g npm && npm ci
 - npm install svgexport -g
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - openjdk8
 before_install:
 - export CXX='g++-4.8'
-- nvm install 12.18.3 && nvm use 12.18.3 && npm install -g npm && npm ci
+- nvm install 12.18.2 && nvm use 12.18.2 && npm install -g npm && npm ci
 - npm install svgexport -g
 cache:
   directories:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,21 @@
         "@azu/format-text": "^1.0.1"
       }
     },
+    "@babel/parser": {
+      "version": "7.11.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
+      "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
+      "dev": true
+    },
+    "@textlint-rule/textlint-rule-no-invalid-control-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-1.2.0.tgz",
+      "integrity": "sha512-FgkOQr14H8D/LQVAEOR2cGWhzItb9MXCAvaBwKkysIfP9Ngwam+8NRmbphQ/GrAm3PXV63QmK1xwAKM1DntwmQ==",
+      "dev": true,
+      "requires": {
+        "execall": "^1.0.0"
+      }
+    },
     "@textlint/ast-node-types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-2.0.0.tgz",
@@ -52,6 +67,26 @@
         "object-assign": "^4.1.1",
         "structured-source": "^3.0.2",
         "txt-ast-traverse": "^1.2.1"
+      }
+    },
+    "@textlint/module-interop": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-1.1.4.tgz",
+      "integrity": "sha512-9M3kYG5nBoD2lhp05sqi6fieNU6rBcf+A8Trp+4d8o5uJ4RRsWeRtAQMWM7Tv15onqIITRq7fm3la7xovVB9KA==",
+      "dev": true
+    },
+    "@textlint/regexp-string-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-1.1.0.tgz",
+      "integrity": "sha512-uTPnE1Dw1j+9clXPn61ZUdtg+WyhbgeXHwCTfBev7quHjeCP9PS8NdRkR6wEgmjuLg+xZlI4r/e1r6Bd0xyusQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "execall": "^1.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0",
+        "to-regex": "^3.0.2"
       }
     },
     "@textlint/types": {
@@ -197,25 +232,12 @@
       }
     },
     "analyze-desumasu-dearu": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-3.1.0.tgz",
-      "integrity": "sha1-rza5SEVMB4OkMfKrk4pZ8k1A4VA=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-4.0.1.tgz",
+      "integrity": "sha512-lnQYEs+jXrtRJcgLCDrNwOqHziYv5adxpElkt8QMKwLxg1m5X6n6XGi/un7zg20Bcg9eFiXSGElt0bBWA3wHEg==",
       "dev": true,
       "requires": {
-        "array-find": "^1.0.0",
-        "kuromojin": "^1.2.1",
-        "object.assign": "^4.0.3"
-      },
-      "dependencies": {
-        "kuromojin": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
-          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
-          "dev": true,
-          "requires": {
-            "kuromoji": "0.1.1"
-          }
-        }
+        "kuromojin": "^2.0.0"
       }
     },
     "ansi-align": {
@@ -260,12 +282,6 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
-    "array-find": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -289,6 +305,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "async": {
@@ -1199,6 +1221,16 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
+    "clone-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1493,6 +1525,16 @@
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "delayed-stream": {
@@ -1935,11 +1977,30 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "execall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
+      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      }
     },
     "external-editor": {
       "version": "2.2.0",
@@ -2608,6 +2669,15 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
@@ -2662,6 +2732,15 @@
         "ci-info": "^1.5.0"
       }
     },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
@@ -2673,6 +2752,26 @@
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      }
+    },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
     },
     "is-file": {
       "version": "1.0.0",
@@ -2753,6 +2852,15 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -2774,6 +2882,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -2790,6 +2904,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-supported-regexp-flag": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-symbol": {
@@ -2841,6 +2961,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
@@ -2986,6 +3112,12 @@
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -3080,6 +3212,24 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.uniqwith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
+      "integrity": "sha1-egy/ZfQ7WShiWp1NDcVLGMrcfvM=",
       "dev": true
     },
     "log-symbols": {
@@ -7022,6 +7172,7 @@
             },
             "dezalgo": {
               "version": "1.0.3",
+              "resolved": false,
               "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
@@ -7048,6 +7199,7 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
+              "resolved": false,
               "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
               "dev": true,
               "requires": {
@@ -7300,6 +7452,8 @@
                             },
                             "concat-map": {
                               "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -7308,6 +7462,8 @@
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                       "dev": true
                     }
                   }
@@ -7724,6 +7880,7 @@
             },
             "normalize-git-url": {
               "version": "3.0.2",
+              "resolved": false,
               "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
               "dev": true
             },
@@ -7766,6 +7923,7 @@
             },
             "npm-install-checks": {
               "version": "3.0.0",
+              "resolved": false,
               "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "dev": true,
               "requires": {
@@ -7827,10 +7985,14 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                           "dev": true
                         },
                         "process-nextick-args": {
@@ -7841,10 +8003,14 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                           "dev": true
                         }
                       }
@@ -8306,6 +8472,8 @@
                             },
                             "concat-map": {
                               "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -8314,6 +8482,8 @@
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                       "dev": true
                     }
                   }
@@ -8373,6 +8543,8 @@
                 },
                 "core-util-is": {
                   "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true
                 },
                 "isarray": {
@@ -8389,6 +8561,8 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "dev": true
                 },
                 "util-deprecate": {
@@ -8413,6 +8587,7 @@
             },
             "realize-package-specifier": {
               "version": "3.0.3",
+              "resolved": false,
               "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
               "dev": true,
               "requires": {
@@ -9080,6 +9255,7 @@
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
+                  "resolved": false,
                   "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "dev": true,
                   "requires": {
@@ -9139,6 +9315,8 @@
                     },
                     "spdx-license-ids": {
                       "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
+                      "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
                       "dev": true
                     }
                   }
@@ -9440,11 +9618,14 @@
             },
             "ansicolors": {
               "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
               "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+              "integrity": "sha512-6QWEyvMgIXX0eO972y7YPBLSBsq7UWKFAoNNTLGaOJ9bstcEL9sCbcjf96dVfNDdUsRoGOK82vWFJlKApXds7g==",
               "dev": true
             },
             "archy": {
@@ -9455,6 +9636,7 @@
             },
             "async-some": {
               "version": "1.0.2",
+              "resolved": false,
               "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
               "dev": true,
               "requires": {
@@ -9558,6 +9740,7 @@
             },
             "dezalgo": {
               "version": "1.0.3",
+              "resolved": false,
               "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
@@ -9612,6 +9795,7 @@
             },
             "fstream": {
               "version": "1.0.10",
+              "resolved": false,
               "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
               "dev": true,
               "requires": {
@@ -9652,6 +9836,7 @@
             },
             "github-url-from-username-repo": {
               "version": "1.0.2",
+              "resolved": false,
               "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
               "dev": true
             },
@@ -9884,6 +10069,7 @@
             },
             "nopt": {
               "version": "3.0.6",
+              "resolved": false,
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
@@ -10195,6 +10381,7 @@
             "path-is-inside": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+              "integrity": "sha512-SBjqBPwe10u8a3phuxQZMZ68VZ4bHMFV8BsXf37s6+GoIjMcL4KmcOW0VGAyTuekHZdsVM79HgirZANGPFRrvg==",
               "dev": true
             },
             "read": {
@@ -10216,6 +10403,7 @@
             },
             "read-installed": {
               "version": "4.0.3",
+              "resolved": false,
               "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
@@ -10236,6 +10424,7 @@
                 },
                 "readdir-scoped-modules": {
                   "version": "1.0.2",
+                  "resolved": false,
                   "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
                   "dev": true,
                   "requires": {
@@ -11022,6 +11211,7 @@
             },
             "tar": {
               "version": "2.2.1",
+              "resolved": false,
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
@@ -11032,6 +11222,8 @@
             },
             "text-table": {
               "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "dev": true
             },
             "uid-number": {
@@ -11087,6 +11279,7 @@
             },
             "validate-npm-package-name": {
               "version": "2.2.2",
+              "resolved": false,
               "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
               "dev": true,
               "requires": {
@@ -11095,6 +11288,8 @@
               "dependencies": {
                 "builtins": {
                   "version": "0.0.7",
+                  "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+                  "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
                   "dev": true
                 }
               }
@@ -11124,6 +11319,7 @@
             },
             "write-file-atomic": {
               "version": "1.1.4",
+              "resolved": false,
               "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
@@ -11621,13 +11817,22 @@
       "dev": true
     },
     "prh": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prh/-/prh-3.1.1.tgz",
-      "integrity": "sha512-o+WraRm9LvMeBUbqeTEA8fJ1tQUZ12swFvK65HLuzzQVxIxHjxOQ5IJK1GBcSstT4AuX7kdzl8YoZbEdOLHfaA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.4.tgz",
+      "integrity": "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==",
       "dev": true,
       "requires": {
-        "commandpost": "^1.2.0",
+        "commandpost": "^1.2.1",
+        "diff": "^4.0.1",
         "js-yaml": "^3.9.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
       }
     },
     "private": {
@@ -11828,6 +12033,16 @@
         "babel-runtime": "^6.18.0",
         "babel-types": "^6.19.0",
         "private": "^0.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -12087,6 +12302,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -12122,6 +12343,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -13055,14 +13285,43 @@
       }
     },
     "textlint-rule-no-mix-dearu-desumasu": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-3.0.3.tgz",
-      "integrity": "sha1-rEuBYLT0ZkSkpA1i/gHY23Zwt8M=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-4.0.1.tgz",
+      "integrity": "sha512-brkZc+l3Y34C31zHXyMUITbdsHj0i1MeZ7IQfhR38nvXzHlKWWFqoesXndLSml6yiVIJn4glJhiiJ1yErm86Sw==",
       "dev": true,
       "requires": {
-        "analyze-desumasu-dearu": "^3.1.0",
+        "analyze-desumasu-dearu": "^4.0.0",
         "textlint-rule-helper": "^2.0.0",
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "^2.0.2"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+          "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
+          "dev": true
+        },
+        "unist-util-visit": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
+          "integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0"
+          }
+        }
       }
     },
     "textlint-rule-no-nfd": {
@@ -13077,32 +13336,35 @@
       }
     },
     "textlint-rule-preset-japanese": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-2.0.0.tgz",
-      "integrity": "sha1-y6bERWyWgqylJ6upN7MopHMOKxY=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-5.0.0.tgz",
+      "integrity": "sha512-Gre9SYl7tPFaPzpIQlGuAzUjn1tfgAso20ScOhupOUTeuVFo+C9u/v/5PYmpozKV+i2CC0/xLonk+FZNcNi9KA==",
       "dev": true,
       "requires": {
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^1.2.0",
+        "@textlint/module-interop": "^1.0.1",
         "textlint-rule-max-ten": "^2.0.2",
         "textlint-rule-no-double-negative-ja": "^1.0.3",
         "textlint-rule-no-doubled-conjunction": "^1.0.2",
-        "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.0.2",
+        "textlint-rule-no-doubled-conjunctive-particle-ga": "^1.1.0",
         "textlint-rule-no-doubled-joshi": "^3.0.0",
         "textlint-rule-no-dropping-the-ra": "^1.1.2",
-        "textlint-rule-no-mix-dearu-desumasu": "^3.0.0",
+        "textlint-rule-no-mix-dearu-desumasu": "^4.0.0",
         "textlint-rule-no-nfd": "^1.0.1",
-        "textlint-rule-prh": "^4.0.1",
-        "textlint-rule-sentence-length": "^1.0.4"
+        "textlint-rule-prh": "^5.2.0",
+        "textlint-rule-sentence-length": "^2.1.1"
       },
       "dependencies": {
         "textlint-rule-prh": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-4.0.1.tgz",
-          "integrity": "sha1-d9qcAbyUpZJ7leva5nPyU2vXx10=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-5.3.0.tgz",
+          "integrity": "sha512-gdod+lL1SWUDyXs1ICEwvQawaSshT3mvPGufBIjF2R5WFPdKQDMsiuzsjkLm+aF+9d97dA6pFsiyC8gSW7mSgg==",
           "dev": true,
           "requires": {
-            "prh": "^3.0.1",
-            "textlint-rule-helper": "^2.0.0",
-            "untildify": "^3.0.2"
+            "@babel/parser": "^7.7.5",
+            "prh": "^5.4.4",
+            "textlint-rule-helper": "^2.1.1",
+            "untildify": "^3.0.3"
           }
         }
       }
@@ -13163,24 +13425,115 @@
       }
     },
     "textlint-rule-sentence-length": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-1.1.3.tgz",
-      "integrity": "sha512-iyzUFB+LbHlzW/rpY4Vlddf3/w0iRmMxi1QwlbKl5fRAhvkXsF4ZJOKHPLIB7eOxQKShftLo/zImxZTXMmVfrg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-sentence-length/-/textlint-rule-sentence-length-2.2.0.tgz",
+      "integrity": "sha512-0C7XZvqcdDwBQC1Sfyr47uDAChH0dO3O4gjxG4C/cwRFK8cyjIic8h7g+xaN7c9x+4OoMz+89SksuaHLo5UvqQ==",
       "dev": true,
       "requires": {
-        "sentence-splitter": "^2.0.0",
-        "textlint-rule-helper": "^2.0.0",
-        "textlint-util-to-string": "^2.1.1"
+        "@textlint/regexp-string-matcher": "^1.1.0",
+        "sentence-splitter": "^3.0.11",
+        "textlint-rule-helper": "^2.1.1",
+        "textlint-util-to-string": "^3.0.0"
       },
       "dependencies": {
-        "textlint-util-to-string": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-2.1.1.tgz",
-          "integrity": "sha512-PW6rXqLNGL3xZ6d5/INrX+pt8qbffmeDPLcvkBOlfNpDRFhVvNNjFmZXH86ZQjrOz9t/nNZDBXqnzqJuioJbSQ==",
+        "@textlint/ast-node-types": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
+          "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "sentence-splitter": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.0.tgz",
+          "integrity": "sha512-lKX2tZ1rsA9Tu0gW8vRmMDmIEJoZ1d7cKpzcbFZdUrSpCR6gy/7OPPh7jjT/6Oc6Z79ToUmC2l8tyTEGanVmiA==",
+          "dev": true,
+          "requires": {
+            "@textlint/ast-node-types": "^4.2.5",
+            "concat-stream": "^2.0.0",
+            "object.values": "^1.1.0",
             "structured-source": "^3.0.2"
+          }
+        },
+        "textlint-util-to-string": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.1.1.tgz",
+          "integrity": "sha512-mHE7/pDw/Hk+Q6YdSMNRrZPl5bCuWnFLbF+bxW+MsWQ64dw+Ia9irkammYbH5I0hVMMcfwb0MQc5nbsjqgWeyQ==",
+          "dev": true,
+          "requires": {
+            "@textlint/ast-node-types": "^4.2.4",
+            "@types/structured-source": "^3.0.0",
+            "rehype-parse": "^6.0.1",
+            "structured-source": "^3.0.2",
+            "unified": "^8.4.0"
+          }
+        },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        },
+        "vfile": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+          "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
           }
         }
       }
@@ -13233,6 +13586,18 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,22 +54,51 @@
         "txt-ast-traverse": "^1.2.1"
       }
     },
+    "@textlint/types": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.4.5.tgz",
+      "integrity": "sha512-7pA1rdiw1jsDNGwxupMC6fPlRNAHY6fKZ3s+jAY53o6RroOSR+5qO0sAjJ26lsSOhveH8imZzyyD08dk58IVJQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.3.4"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
+          "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
+          "dev": true
+        }
+      }
+    },
     "@types/bluebird": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
-      "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
+      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==",
       "dev": true
     },
     "@types/node": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+      "dev": true
+    },
+    "@types/structured-source": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/structured-source/-/structured-source-3.0.0.tgz",
+      "integrity": "sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
     "acorn": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.0.tgz",
-      "integrity": "sha512-QatFQ4C0n+PLqemyC6zXEv04tSqRR0hRqe+uGKPEVgKe2G8kl8wJvHzRYWwz6vqqEqt6idPVMFojZ4P1zlyAzQ==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-es7-plugin": {
@@ -176,6 +205,17 @@
         "array-find": "^1.0.0",
         "kuromojin": "^1.2.1",
         "object.assign": "^4.0.3"
+      },
+      "dependencies": {
+        "kuromojin": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.5.1.tgz",
+          "integrity": "sha512-tzt3UUqWqzwHMsahchyrcs9kgbn6OM7xP4QRCd0w5vqE0lA/cjCH0OxjLaekz5cnxGmcy8RfN7La3xOxZOvJ1w==",
+          "dev": true,
+          "requires": {
+            "kuromoji": "0.1.1"
+          }
+        }
       }
     },
     "ansi-align": {
@@ -188,9 +228,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -206,18 +246,18 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
     "array-find": {
@@ -231,55 +271,19 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
-    "array-iterate": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.1.tgz",
-      "integrity": "sha1-hlv3+K851rCYLGCQKRSsdrwBCPY=",
-      "dev": true
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -288,10 +292,9 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -306,9 +309,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
     },
     "babel-code-frame": {
@@ -347,6 +350,14 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -363,6 +374,14 @@
         "lodash": "^4.17.4",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "babel-helper-call-delegate": {
@@ -486,9 +505,9 @@
       }
     },
     "babel-plugin-empower-assert": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-empower-assert/-/babel-plugin-empower-assert-1.3.0.tgz",
-      "integrity": "sha1-V/TwKGeT5YUVTn4+q2dUQLkiNDw=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-empower-assert/-/babel-plugin-empower-assert-1.4.0.tgz",
+      "integrity": "sha512-FeISXIDYf1y/nDCiAETOKbXkJ0XIctmLltC3zZqzFY+91GlMFNIf1mgHeeDif8tIu/m+18Z/FY4/OG+0L/QADg==",
       "dev": true
     },
     "babel-plugin-espower": {
@@ -875,9 +894,9 @@
       "dev": true
     },
     "bail": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
-      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
       "dev": true
     },
     "balanced-match": {
@@ -893,19 +912,18 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "boolbase": {
@@ -944,12 +962,6 @@
             "color-convert": "^1.9.0"
           }
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -960,12 +972,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -979,9 +985,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -994,15 +1000,22 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
-    "builtin-modules": {
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "call-matcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
-      "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
+      "integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -1032,6 +1045,11 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
     "camelcase-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
@@ -1040,13 +1058,6 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
       }
     },
     "capture-stack-trace": {
@@ -1072,9 +1083,9 @@
       "dev": true
     },
     "ccount": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
-      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
       "dev": true
     },
     "chalk": {
@@ -1091,27 +1102,27 @@
       }
     },
     "character-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
-      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
       "dev": true
     },
     "character-entities-html4": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
-      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
       "dev": true
     },
     "character-entities-legacy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
-      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
       "dev": true
     },
     "character-reference-invalid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
-      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
     "chardet": {
@@ -1183,9 +1194,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "co": {
@@ -1207,9 +1218,9 @@
       "dev": true
     },
     "collapse-white-space": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
-      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "collections": {
@@ -1222,12 +1233,12 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1242,13 +1253,19 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
@@ -1257,9 +1274,9 @@
       "dev": true
     },
     "commandpost": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.3.0.tgz",
-      "integrity": "sha512-T62tyrmYTkaRDbV2z1k2yXTyxk0cFptXYwo1cUbnfHtp7ThLgQ9/90jG1Ym5WLZgFhvOTaHA5VSARWJ9URpLDw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.4.0.tgz",
+      "integrity": "sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==",
       "dev": true
     },
     "concat-map": {
@@ -1269,14 +1286,41 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "configstore": {
@@ -1294,15 +1338,18 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
     "core-util-is": {
@@ -1356,9 +1403,9 @@
       }
     },
     "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
       "dev": true
     },
     "currently-unhandled": {
@@ -1414,10 +1461,18 @@
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -1432,28 +1487,12 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
-      }
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "object-keys": "^1.0.12"
       }
     },
     "delayed-stream": {
@@ -1478,9 +1517,9 @@
       "dev": true
     },
     "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "dev": true
     },
     "doctrine": {
@@ -1493,33 +1532,25 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -1563,35 +1594,35 @@
       "dev": true
     },
     "eastasianwidth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
-      "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "empower": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
-      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/empower/-/empower-1.3.1.tgz",
+      "integrity": "sha512-uB6/ViBaawOO/uujFADTK3SqdYlxYNn+N4usK9MRKZ4Hbn/1QSy8k2PezxCA2/+JGbF8vd/eOfghZ90oOSDZCA==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "empower-core": "^0.6.2"
+        "empower-core": "^1.2.0"
       }
     },
     "empower-core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
-      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+      "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
@@ -1599,41 +1630,53 @@
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
+        "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1703,9 +1746,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -1714,24 +1757,24 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "globals": {
-          "version": "11.5.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-          "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "strip-ansi": {
@@ -1744,9 +1787,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -1764,9 +1807,9 @@
       }
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -1774,9 +1817,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espower-location-detector": {
@@ -1789,6 +1832,14 @@
         "path-is-absolute": "^1.0.0",
         "source-map": "^0.5.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "espree": {
@@ -1802,27 +1853,35 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+      "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0"
       }
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -1835,15 +1894,15 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "event-stream": {
@@ -1894,26 +1953,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.0",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       }
     },
     "extsprintf": {
@@ -1928,9 +1976,9 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-diff": {
@@ -1940,9 +1988,9 @@
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1952,9 +2000,9 @@
       "dev": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -1980,32 +2028,24 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2014,13 +2054,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -2060,10 +2100,13 @@
       "dev": true
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
@@ -2193,9 +2236,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2221,20 +2264,6 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -2255,9 +2284,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growl": {
       "version": "1.10.3",
@@ -2266,37 +2295,15 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "uglify-js": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
-          "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.3",
-            "source-map": "~0.6.1"
-          }
-        }
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       }
     },
     "har-schema": {
@@ -2306,22 +2313,48 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^5.1.0",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2334,15 +2367,15 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "hasha": {
@@ -2353,6 +2386,37 @@
       "requires": {
         "is-stream": "^1.0.1",
         "pinkie-promise": "^2.0.0"
+      }
+    },
+    "hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
+      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA==",
+      "dev": true
+    },
+    "hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dev": true,
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
       }
     },
     "he": {
@@ -2372,22 +2436,22 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "readable-stream": "^3.1.1"
       }
     },
     "http-signature": {
@@ -2402,18 +2466,18 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "import-lazy": {
@@ -2450,9 +2514,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ini": {
@@ -2499,21 +2563,15 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -2525,9 +2583,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -2542,18 +2600,18 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
     },
     "is-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
-      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
       "dev": true
     },
     "is-alphanumeric": {
@@ -2563,14 +2621,20 @@
       "dev": true
     },
     "is-alphanumerical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
-      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "dev": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
       }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2583,18 +2647,10 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-ci": {
@@ -2607,15 +2663,15 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
-      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
       "dev": true
     },
     "is-file": {
@@ -2625,13 +2681,10 @@
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -2640,9 +2693,9 @@
       "dev": true
     },
     "is-hexadecimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
-      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
     "is-installed-globally": {
@@ -2655,14 +2708,21 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
         "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
@@ -2679,21 +2739,6 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -2708,12 +2753,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -2727,12 +2766,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -2742,9 +2781,9 @@
       "dev": true
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -2754,10 +2793,13 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2766,9 +2808,9 @@
       "dev": true
     },
     "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -2778,15 +2820,15 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
-      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
-      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "isarray": {
@@ -2831,9 +2873,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2844,8 +2886,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "jsesc": {
       "version": "1.3.0",
@@ -2922,9 +2963,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
       "dev": true
     },
     "jsprim": {
@@ -2972,29 +3013,29 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "^4.17.14"
           }
         }
       }
     },
     "kuromojin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-1.4.0.tgz",
-      "integrity": "sha512-ZoG3NAW6ATKgo2jBgjVWwE66GeaT2jHgdf0v1dL8+WffuSfvTvX7l6ePgYusSAhHW+dwtneYcbav8N0NhsA0uw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-2.0.0.tgz",
+      "integrity": "sha512-60j/yLkFSc4t4roj8tI8ZNNSiAFnrkgXw8SqXz/9nakfs6mkCvPbrd7S8LDr4YNwEt1IyLys5JQTR9EnYyGHhA==",
       "dev": true,
       "requires": {
         "kuromoji": "0.1.1"
       }
     },
     "language-map": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/language-map/-/language-map-1.3.0.tgz",
-      "integrity": "sha512-8efzmVFALFsxdzjFLBvXlNKxBq2mT75mprBb/lLCSIwyClbwOmogaCnfJvly5NRCuSORjmp0xn0IAmZz7wSWOg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/language-map/-/language-map-1.4.0.tgz",
+      "integrity": "sha512-5XHMCqKQ/14VXwJTKZX7MZwsVyTrR0bwCsRBwrBq3nP4w7liMJiR0ixXgI29EF/T1/U6be8cYK2y0ibWW9kx2w=="
     },
     "latest-version": {
       "version": "3.1.0",
@@ -3016,16 +3057,14 @@
       }
     },
     "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -3035,19 +3074,12 @@
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        }
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {
@@ -3060,18 +3092,18 @@
       }
     },
     "longest-streak": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -3090,9 +3122,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -3106,14 +3138,6 @@
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
       }
     },
     "map-like": {
@@ -3134,15 +3158,15 @@
       "dev": true
     },
     "markdown-escapes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
-      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
     "markdown-table": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.1.tgz",
-      "integrity": "sha1-Sz3ToTPRUYuO8NvHCb8qG0gkvIw=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
       "dev": true
     },
     "markdown-to-ast": {
@@ -3159,39 +3183,38 @@
       }
     },
     "match-index": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.1.tgz",
-      "integrity": "sha1-tLZz6ZqzrFpq8wPM9NtwmBK8P1g=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/match-index/-/match-index-1.0.3.tgz",
+      "integrity": "sha512-1XjyBWqCvEFFUDW/MPv0RwbITRD4xQXOvKoPYtLDq8IdZTfdF/cQSo5Yn4qvhfSSZgjgkTFsqJD2wOUG4ovV8Q==",
       "dev": true,
       "requires": {
         "regexp.prototype.flags": "^1.1.1"
       }
     },
     "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "dev": true,
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "mdast-util-compact": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
-      "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
+      "integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
       "dev": true,
       "requires": {
-        "unist-util-modify-children": "^1.0.0",
         "unist-util-visit": "^1.1.0"
       }
     },
     "memory-streams": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.2.tgz",
-      "integrity": "sha1-Jz/3d6tg/sWZsRY1UlUoLMosUMI=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
       "dev": true,
       "requires": {
         "readable-stream": "~1.0.2"
@@ -3237,78 +3260,6 @@
         "read-pkg-up": "^3.0.0",
         "redent": "^2.0.0",
         "trim-newlines": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
       }
     },
     "mime": {
@@ -3318,18 +3269,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimeparse": {
@@ -3354,9 +3305,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -3368,12 +3319,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -3401,6 +3352,41 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "supports-color": {
@@ -3444,9 +3430,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true
     },
     "natural-compare": {
@@ -3456,9 +3442,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-alias": {
       "version": "1.0.4",
@@ -3471,12 +3457,12 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
@@ -3587,7 +3573,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
           "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -3596,54 +3583,64 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
               "dev": true
             },
             "through": {
               "version": "2.3.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
               "dev": true
             }
           }
         },
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "bluebird": {
           "version": "3.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
         },
         "cacache": {
           "version": "9.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz",
+          "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.0",
@@ -3663,7 +3660,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+              "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -3672,36 +3670,42 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                   "dev": true
                 }
               }
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3710,7 +3714,8 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -3719,7 +3724,8 @@
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -3727,14 +3733,16 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "dev": true,
               "requires": {
                 "defaults": "^1.0.3"
@@ -3742,7 +3750,8 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
                     "clone": "^1.0.2"
@@ -3750,7 +3759,8 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
                   }
@@ -3761,7 +3771,8 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -3770,19 +3781,22 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "dezalgo": {
@@ -3793,16 +3807,26 @@
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
+          },
+          "dependencies": {
+            "asap": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
+              "dev": true
+            }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3812,7 +3836,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3823,7 +3848,8 @@
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3834,7 +3860,8 @@
         },
         "fstream-npm": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.1.tgz",
+          "integrity": "sha512-iBHpm/LmD1qw0TlHMAqVd9rwdU6M+EHRUnPkXpRi5G/Hf0FIFH+oZFryodAU2MFNfGRh/CzhUFlMKV3pdeOTDw==",
           "dev": true,
           "requires": {
             "fstream-ignore": "^1.0.0",
@@ -3843,7 +3870,8 @@
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -3853,7 +3881,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
@@ -3861,7 +3890,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^1.0.0",
@@ -3870,12 +3900,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -3888,7 +3920,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3901,12 +3934,14 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -3914,7 +3949,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
@@ -3923,12 +3959,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -3937,39 +3975,46 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -3978,17 +4023,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+          "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -4003,7 +4051,8 @@
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
                 "read": "1"
@@ -4013,22 +4062,26 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "lockfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -4037,29 +4090,34 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
               "dev": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
               "dev": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -4067,37 +4125,44 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -4106,19 +4171,22 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "mississippi": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+          "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
@@ -4135,7 +4203,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
@@ -4145,14 +4214,16 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "duplexify": {
               "version": "3.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+              "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.0.0",
@@ -4163,7 +4234,8 @@
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                   "dev": true,
                   "requires": {
                     "once": "~1.3.0"
@@ -4171,7 +4243,8 @@
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                       "dev": true,
                       "requires": {
                         "wrappy": "1"
@@ -4181,14 +4254,16 @@
                 },
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
               "dev": true,
               "requires": {
                 "once": "^1.4.0"
@@ -4196,7 +4271,8 @@
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
               "dev": true,
               "requires": {
                 "inherits": "^2.0.1",
@@ -4205,7 +4281,8 @@
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "dev": true,
               "requires": {
                 "inherits": "^2.0.1",
@@ -4214,7 +4291,8 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "dev": true,
               "requires": {
                 "cyclist": "~0.2.2",
@@ -4224,14 +4302,16 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                   "dev": true
                 }
               }
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+              "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -4240,7 +4320,8 @@
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+              "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
               "dev": true,
               "requires": {
                 "duplexify": "^3.1.2",
@@ -4250,7 +4331,8 @@
             },
             "stream-each": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+              "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -4259,14 +4341,16 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "dev": true,
               "requires": {
                 "readable-stream": "^2.1.5",
@@ -4275,7 +4359,8 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
@@ -4284,7 +4369,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -4292,14 +4378,16 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -4312,7 +4400,8 @@
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz",
+              "integrity": "sha1-Rft4ZiSaHKiJqlcI5svSc+dbslA=",
               "dev": true,
               "requires": {
                 "aproba": "^1.1.1",
@@ -4325,7 +4414,8 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "dev": true,
               "requires": {
                 "aproba": "^1.1.1"
@@ -4335,7 +4425,8 @@
         },
         "node-gyp": {
           "version": "3.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dev": true,
           "requires": {
             "fstream": "^1.0.0",
@@ -4355,7 +4446,8 @@
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -4363,7 +4455,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
@@ -4372,12 +4465,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -4386,7 +4481,8 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
                 "abbrev": "1"
@@ -4396,7 +4492,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -4405,7 +4502,8 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -4416,7 +4514,8 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
                 "builtin-modules": "^1.0.0"
@@ -4424,7 +4523,8 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                   "dev": true
                 }
               }
@@ -4433,12 +4533,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -4446,7 +4548,8 @@
         },
         "npm-package-arg": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+          "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.4.2",
@@ -4457,7 +4560,8 @@
         },
         "npm-registry-client": {
           "version": "8.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.4.0.tgz",
+          "integrity": "sha512-PVNfqq0lyRdFnE//nDmn3CC9uqTsr8Bya9KPLIevlXMfkP0m4RpCVyFFk0W1Gfx436kKwyhLA6J+lV+rgR81gQ==",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.2",
@@ -4475,7 +4579,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
@@ -4485,7 +4590,8 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
@@ -4494,12 +4600,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -4510,7 +4618,8 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "requires": {
                 "delegates": "^1.0.0",
@@ -4519,19 +4628,22 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "requires": {
                 "aproba": "^1.0.3",
@@ -4546,17 +4658,20 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
@@ -4566,12 +4681,14 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                       "dev": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
                       "requires": {
                         "number-is-nan": "^1.0.0"
@@ -4579,7 +4696,8 @@
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                           "dev": true
                         }
                       }
@@ -4588,7 +4706,8 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -4596,14 +4715,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                  "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                   "dev": true,
                   "requires": {
                     "string-width": "^1.0.2"
@@ -4613,14 +4734,16 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -4628,12 +4751,14 @@
         },
         "opener": {
           "version": "1.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -4642,19 +4767,22 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true
             }
           }
         },
         "pacote": {
           "version": "2.7.38",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
+          "integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.0",
@@ -4682,7 +4810,8 @@
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.4.13",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.13.tgz",
+              "integrity": "sha512-73CsTlMRSLdGr7VvOE8iYl/ejOSIxyfRYg7jZhepGGEqIlgdq6FLe2DEAI5bo813Jdg5fS/Ku62SRQ/UpT6NJA==",
               "dev": true,
               "requires": {
                 "agentkeepalive": "^3.3.0",
@@ -4700,7 +4829,8 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
                     "humanize-ms": "^1.2.1"
@@ -4708,7 +4838,8 @@
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
                         "ms": "^2.0.0"
@@ -4716,7 +4847,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -4725,12 +4857,14 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.7.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.7.3.tgz",
+                  "integrity": "sha1-LzXFMuzSnx5UE7mvgztySjxvf3I=",
                   "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
                     "agent-base": "4",
@@ -4739,7 +4873,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "^5.0.0"
@@ -4747,7 +4882,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "^4.0.3"
@@ -4755,7 +4891,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -4764,7 +4901,8 @@
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -4772,7 +4910,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -4781,7 +4920,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-/6pLb69YasNAwYoUBDHna31/KUQ=",
                   "dev": true,
                   "requires": {
                     "agent-base": "^4.1.0",
@@ -4790,7 +4930,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "^5.0.0"
@@ -4798,7 +4939,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "^4.0.3"
@@ -4806,7 +4948,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -4815,7 +4958,8 @@
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -4823,7 +4967,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -4832,7 +4977,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.1.tgz",
+                  "integrity": "sha512-W3onhopST5tqpX0/MGSL47pDQLLKobNR83AvkiOWQKaw54h+uYUfzeLAxCiyhWlUOiuI+GIb4O9ojLaAFlhCCA==",
                   "dev": true,
                   "requires": {
                     "encoding": "^0.1.11",
@@ -4842,7 +4988,8 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
                         "iconv-lite": "~0.4.13"
@@ -4850,14 +4997,16 @@
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.18",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+                          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
                           "dev": true
                         }
                       }
                     },
                     "json-parse-helpfulerror": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                       "dev": true,
                       "requires": {
                         "jju": "^1.1.0"
@@ -4865,7 +5014,8 @@
                       "dependencies": {
                         "jju": {
                           "version": "1.3.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                          "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                           "dev": true
                         }
                       }
@@ -4874,7 +5024,8 @@
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.0.tgz",
+                  "integrity": "sha512-YJcT+SNNBgFoK/NpO20PChz0VnBOhkjG3X10BwlrYujd0NZlSsH1jbxSQ1S0njt3sOvzwQ2PvGqqUIvP4rNk/w==",
                   "dev": true,
                   "requires": {
                     "agent-base": "^4.0.1",
@@ -4883,7 +5034,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.0.tgz",
+                      "integrity": "sha1-IOF0Ac1Js8B2v1akvGxbQ2/6jVU=",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "^5.0.0"
@@ -4891,7 +5043,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "^4.0.3"
@@ -4899,7 +5052,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -4908,7 +5062,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
                         "ip": "^1.1.4",
@@ -4917,12 +5072,14 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                           "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                           "dev": true
                         }
                       }
@@ -4933,7 +5090,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
@@ -4941,7 +5099,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
@@ -4950,12 +5109,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -4964,7 +5125,8 @@
             },
             "npm-pick-manifest": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
+              "integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
               "dev": true,
               "requires": {
                 "npm-package-arg": "^5.1.2",
@@ -4973,7 +5135,8 @@
             },
             "promise-retry": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "dev": true,
               "requires": {
                 "err-code": "^1.0.0",
@@ -4982,14 +5145,16 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                  "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                   "dev": true
                 }
               }
             },
             "protoduck": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+              "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
               "dev": true,
               "requires": {
                 "genfun": "^4.0.1"
@@ -4997,14 +5162,16 @@
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                   "dev": true
                 }
               }
             },
             "tar-fs": {
               "version": "1.15.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
+              "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
               "dev": true,
               "requires": {
                 "chownr": "^1.0.1",
@@ -5015,7 +5182,8 @@
               "dependencies": {
                 "pump": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+                  "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
                   "dev": true,
                   "requires": {
                     "end-of-stream": "^1.1.0",
@@ -5024,7 +5192,8 @@
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                       "dev": true,
                       "requires": {
                         "once": "^1.4.0"
@@ -5036,7 +5205,8 @@
             },
             "tar-stream": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+              "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
               "dev": true,
               "requires": {
                 "bl": "^1.0.0",
@@ -5047,7 +5217,8 @@
               "dependencies": {
                 "bl": {
                   "version": "1.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+                  "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "^2.0.5"
@@ -5055,7 +5226,8 @@
                 },
                 "end-of-stream": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+                  "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                   "dev": true,
                   "requires": {
                     "once": "^1.4.0"
@@ -5063,7 +5235,8 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
@@ -5072,17 +5245,20 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -5090,14 +5266,16 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -5105,7 +5283,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -5119,14 +5298,16 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.9.tgz",
+          "integrity": "sha512-vuV8p921IgyelL4UOKv3FsRuRZSaRn30HanLAOKargsr8TbBEq+I3MgloSRXYuKhNdYP1wlEGilMWAIayA2RFg==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -5137,7 +5318,8 @@
           "dependencies": {
             "json-parse-helpfulerror": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
               "requires": {
                 "jju": "^1.1.0"
@@ -5145,7 +5327,8 @@
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                  "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                   "dev": true
                 }
               }
@@ -5154,7 +5337,8 @@
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -5166,7 +5350,8 @@
         },
         "readable-stream": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+          "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5180,22 +5365,26 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -5203,14 +5392,16 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -5221,7 +5412,8 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.6.0",
@@ -5250,22 +5442,26 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "~1.0.0"
@@ -5273,19 +5469,28 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
               }
             },
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+              "dev": true
+            },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "dev": true,
               "requires": {
                 "asynckit": "^0.4.0",
@@ -5295,14 +5500,16 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "dev": true,
               "requires": {
                 "ajv": "^4.9.1",
@@ -5311,7 +5518,8 @@
               "dependencies": {
                 "ajv": {
                   "version": "4.11.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                   "dev": true,
                   "requires": {
                     "co": "^4.6.0",
@@ -5320,12 +5528,14 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                       "dev": true
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "dev": true,
                       "requires": {
                         "jsonify": "~0.0.0"
@@ -5333,7 +5543,8 @@
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                           "dev": true
                         }
                       }
@@ -5342,14 +5553,16 @@
                 },
                 "har-schema": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                  "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
                   "dev": true
                 }
               }
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
                 "boom": "2.x.x",
@@ -5360,7 +5573,8 @@
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -5368,7 +5582,8 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x"
@@ -5376,12 +5591,14 @@
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                   "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                   "dev": true,
                   "requires": {
                     "hoek": "2.x.x"
@@ -5391,7 +5608,8 @@
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "requires": {
                 "assert-plus": "^0.2.0",
@@ -5401,12 +5619,14 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "1.0.0",
@@ -5417,22 +5637,26 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                       "dev": true
                     },
                     "extsprintf": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                       "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2"
@@ -5442,7 +5666,8 @@
                 },
                 "sshpk": {
                   "version": "1.13.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "dev": true,
                   "requires": {
                     "asn1": "~0.2.3",
@@ -5457,17 +5682,20 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                       "dev": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -5476,7 +5704,8 @@
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -5484,7 +5713,8 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -5493,7 +5723,8 @@
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "^1.0.0"
@@ -5501,13 +5732,15 @@
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                       "dev": true,
                       "optional": true
                     }
@@ -5517,22 +5750,26 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "dev": true,
               "requires": {
                 "mime-db": "~1.27.0"
@@ -5540,34 +5777,40 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                  "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
                   "dev": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
               "dev": true
             },
             "qs": {
               "version": "6.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "dev": true,
               "requires": {
                 "punycode": "^1.4.1"
@@ -5575,14 +5818,16 @@
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                   "dev": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.0.1"
@@ -5592,12 +5837,14 @@
         },
         "retry": {
           "version": "0.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -5605,17 +5852,20 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -5624,17 +5874,20 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "^1.3.0",
@@ -5643,7 +5896,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -5652,7 +5906,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -5663,17 +5918,20 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     }
                   }
@@ -5682,7 +5940,8 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "dev": true,
               "requires": {
                 "readable-stream": "^2.1.5",
@@ -5691,7 +5950,8 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
@@ -5700,7 +5960,8 @@
         },
         "ssri": {
           "version": "4.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+          "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.0"
@@ -5708,7 +5969,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -5716,14 +5978,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             }
           }
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "*",
@@ -5733,7 +5997,8 @@
           "dependencies": {
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.0"
@@ -5743,22 +6008,26 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -5766,7 +6035,8 @@
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
                 "imurmurhash": "^0.1.4"
@@ -5776,12 +6046,14 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
+          "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
           "dev": true,
           "requires": {
             "boxen": "^1.0.0",
@@ -5796,7 +6068,8 @@
           "dependencies": {
             "boxen": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.1.0.tgz",
+              "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
               "dev": true,
               "requires": {
                 "ansi-align": "^2.0.0",
@@ -5810,7 +6083,8 @@
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                  "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                   "dev": true,
                   "requires": {
                     "string-width": "^2.0.0"
@@ -5818,17 +6092,20 @@
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+                  "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "^2.0.0",
@@ -5837,12 +6114,14 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                       "dev": true
                     },
                     "strip-ansi": {
                       "version": "4.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "^3.0.0"
@@ -5852,7 +6131,8 @@
                 },
                 "term-size": {
                   "version": "0.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
+                  "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
                   "dev": true,
                   "requires": {
                     "execa": "^0.4.0"
@@ -5860,7 +6140,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+                      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
                       "dev": true,
                       "requires": {
                         "cross-spawn-async": "^2.1.1",
@@ -5873,7 +6154,8 @@
                       "dependencies": {
                         "cross-spawn-async": {
                           "version": "2.2.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+                          "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
                           "dev": true,
                           "requires": {
                             "lru-cache": "^4.0.0",
@@ -5882,12 +6164,14 @@
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "npm-run-path": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+                          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
                           "dev": true,
                           "requires": {
                             "path-key": "^1.0.0"
@@ -5895,17 +6179,20 @@
                         },
                         "object-assign": {
                           "version": "4.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                           "dev": true
                         },
                         "path-key": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+                          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
                           "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                           "dev": true
                         }
                       }
@@ -5914,7 +6201,8 @@
                 },
                 "widest-line": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                   "dev": true,
                   "requires": {
                     "string-width": "^1.0.1"
@@ -5922,7 +6210,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
@@ -5932,12 +6221,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
@@ -5945,14 +6236,16 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "^2.0.0"
@@ -5960,7 +6253,8 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                               "dev": true
                             }
                           }
@@ -5973,7 +6267,8 @@
             },
             "chalk": {
               "version": "1.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
                 "ansi-styles": "^2.2.1",
@@ -5985,17 +6280,20 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                   "dev": true
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                   "dev": true
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -6003,14 +6301,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
@@ -6018,21 +6318,24 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                   "dev": true
                 }
               }
             },
             "configstore": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.0.tgz",
+              "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
               "dev": true,
               "requires": {
                 "dot-prop": "^4.1.0",
@@ -6045,7 +6348,8 @@
               "dependencies": {
                 "dot-prop": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
+                  "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
                   "dev": true,
                   "requires": {
                     "is-obj": "^1.0.0"
@@ -6053,14 +6357,16 @@
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                       "dev": true
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+                  "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                   "dev": true,
                   "requires": {
                     "pify": "^2.3.0"
@@ -6068,14 +6374,16 @@
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                       "dev": true
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                   "dev": true,
                   "requires": {
                     "crypto-random-string": "^1.0.0"
@@ -6083,7 +6391,8 @@
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                       "dev": true
                     }
                   }
@@ -6092,17 +6401,20 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
               "dev": true
             },
             "is-npm": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
               "dev": true
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
               "dev": true,
               "requires": {
                 "package-json": "^4.0.0"
@@ -6110,7 +6422,8 @@
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                  "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                   "dev": true,
                   "requires": {
                     "got": "^6.7.1",
@@ -6121,7 +6434,8 @@
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                       "dev": true,
                       "requires": {
                         "create-error-class": "^3.0.0",
@@ -6139,7 +6453,8 @@
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                           "dev": true,
                           "requires": {
                             "capture-stack-trace": "^1.0.0"
@@ -6147,54 +6462,64 @@
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                               "dev": true
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                           "dev": true
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                           "dev": true
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                           "dev": true
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                           "dev": true
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                           "dev": true
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                           "dev": true,
                           "requires": {
                             "prepend-http": "^1.0.1"
@@ -6202,7 +6527,8 @@
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                               "dev": true
                             }
                           }
@@ -6211,7 +6537,8 @@
                     },
                     "registry-auth-token": {
                       "version": "3.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                       "dev": true,
                       "requires": {
                         "rc": "^1.1.6",
@@ -6220,7 +6547,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "~0.4.0",
@@ -6231,17 +6559,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -6250,7 +6581,8 @@
                     },
                     "registry-url": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                       "dev": true,
                       "requires": {
                         "rc": "^1.0.1"
@@ -6258,7 +6590,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "~0.4.0",
@@ -6269,17 +6602,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -6292,7 +6628,8 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
               "dev": true,
               "requires": {
                 "semver": "^5.0.3"
@@ -6300,19 +6637,22 @@
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
               "dev": true
             }
           }
         },
         "uuid": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "~1.0.0",
@@ -6321,7 +6661,8 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
                 "spdx-license-ids": "^1.0.2"
@@ -6329,21 +6670,24 @@
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                   "dev": true
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
               "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -6351,14 +6695,16 @@
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.2.14",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -6366,14 +6712,16 @@
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "dev": true
             }
           }
         },
         "worker-farm": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+          "integrity": "sha1-QzMRK7SbF6oFC4eJXKayys9A5f8=",
           "dev": true,
           "requires": {
             "errno": ">=0.1.1 <0.2.0-0",
@@ -6382,7 +6730,8 @@
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
               "dev": true,
               "requires": {
                 "prr": "~0.0.0"
@@ -6390,26 +6739,30 @@
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                   "dev": true
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -6445,6 +6798,16 @@
         "update-notifier": "^2.2.0"
       },
       "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
         "npm": {
           "version": "3.10.10",
           "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
@@ -6537,47 +6900,56 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+              "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+              "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
               "dev": true
             },
             "aproba": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+              "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "asap": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -6586,7 +6958,8 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
@@ -6595,7 +6968,8 @@
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+                  "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
                   "dev": true,
                   "requires": {
                     "defaults": "^1.0.0"
@@ -6603,7 +6977,8 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "requires": {
                         "clone": "^1.0.2"
@@ -6611,7 +6986,8 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "dev": true
                         }
                       }
@@ -6622,7 +6998,8 @@
             },
             "config-chain": {
               "version": "1.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+              "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
               "dev": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -6631,19 +7008,21 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "dev": true
                 }
               }
             },
             "debuglog": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+              "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
               "dev": true
             },
             "dezalgo": {
               "version": "1.0.3",
-              "bundled": true,
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -6652,12 +7031,14 @@
             },
             "editor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+              "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -6667,7 +7048,7 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
-              "bundled": true,
+              "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -6678,7 +7059,8 @@
             },
             "fstream": {
               "version": "1.0.10",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -6689,7 +7071,8 @@
             },
             "fstream-npm": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz",
+              "integrity": "sha1-0sPIkQE0aYLWTlcJHDhIe9qRb84=",
               "dev": true,
               "requires": {
                 "fstream-ignore": "^1.0.0",
@@ -6698,7 +7081,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "requires": {
                     "fstream": "^1.0.0",
@@ -6708,7 +7092,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
                         "brace-expansion": "^1.0.0"
@@ -6716,7 +7101,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
                             "balanced-match": "^0.4.1",
@@ -6725,12 +7111,14 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                               "dev": true
                             }
                           }
@@ -6743,7 +7131,8 @@
             },
             "glob": {
               "version": "7.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+              "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -6756,12 +7145,14 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.0.0"
@@ -6769,7 +7160,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^0.4.1",
@@ -6778,12 +7170,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -6792,39 +7186,46 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
               "dev": true
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+              "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -6833,17 +7234,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true
             },
             "init-package-json": {
               "version": "1.9.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+              "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
               "dev": true,
               "requires": {
                 "glob": "^6.0.0",
@@ -6858,7 +7262,8 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
                     "inflight": "^1.0.4",
@@ -6870,7 +7275,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
                         "brace-expansion": "^1.0.0"
@@ -6878,7 +7284,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
                             "balanced-match": "^0.4.1",
@@ -6887,12 +7294,12 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -6901,14 +7308,14 @@
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "promzard": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true,
                   "requires": {
                     "read": "1"
@@ -6918,17 +7325,20 @@
             },
             "lockfile": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.2.tgz",
+              "integrity": "sha1-l+GZAXT2lsvgo6zVikO4SqMMfIM=",
               "dev": true
             },
             "lodash._baseindexof": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+              "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
               "dev": true
             },
             "lodash._baseuniq": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+              "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
               "dev": true,
               "requires": {
                 "lodash._createset": "~4.0.0",
@@ -6937,29 +7347,34 @@
               "dependencies": {
                 "lodash._createset": {
                   "version": "4.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+                  "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                   "dev": true
                 },
                 "lodash._root": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                  "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                   "dev": true
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
               "dev": true
             },
             "lodash._cacheindexof": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+              "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
               "dev": true
             },
             "lodash._createcache": {
               "version": "3.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+              "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
               "dev": true,
               "requires": {
                 "lodash._getnative": "^3.0.0"
@@ -6967,37 +7382,44 @@
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
               "dev": true
             },
             "lodash.clonedeep": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+              "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
               "dev": true
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
               "dev": true
             },
             "lodash.union": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+              "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
               "dev": true
             },
             "lodash.uniq": {
               "version": "4.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+              "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
               "dev": true
             },
             "lodash.without": {
               "version": "4.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+              "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -7005,14 +7427,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "node-gyp": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
+              "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -7033,7 +7457,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "^1.0.0"
@@ -7041,7 +7466,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "^0.4.1",
@@ -7050,12 +7476,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -7064,7 +7492,8 @@
                 },
                 "npmlog": {
                   "version": "3.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+                  "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
                   "dev": true,
                   "requires": {
                     "are-we-there-yet": "~1.1.2",
@@ -7075,7 +7504,8 @@
                   "dependencies": {
                     "are-we-there-yet": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                       "dev": true,
                       "requires": {
                         "delegates": "^1.0.0",
@@ -7084,19 +7514,22 @@
                       "dependencies": {
                         "delegates": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                           "dev": true
                         }
                       }
                     },
                     "console-control-strings": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                       "dev": true
                     },
                     "gauge": {
                       "version": "2.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                      "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
                       "dev": true,
                       "requires": {
                         "aproba": "^1.0.3",
@@ -7112,22 +7545,26 @@
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
                           "dev": true
                         },
                         "object-assign": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
                           "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
                           "dev": true
                         },
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "requires": {
                             "code-point-at": "^1.0.0",
@@ -7137,7 +7574,8 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                              "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                               "dev": true,
                               "requires": {
                                 "number-is-nan": "^1.0.0"
@@ -7145,14 +7583,16 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                                   "dev": true
                                 }
                               }
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "requires": {
                                 "number-is-nan": "^1.0.0"
@@ -7160,7 +7600,8 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                                   "dev": true
                                 }
                               }
@@ -7169,7 +7610,8 @@
                         },
                         "wide-align": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                           "dev": true,
                           "requires": {
                             "string-width": "^1.0.1"
@@ -7179,14 +7621,16 @@
                     },
                     "set-blocking": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                       "dev": true
                     }
                   }
                 },
                 "path-array": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
+                  "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
                   "dev": true,
                   "requires": {
                     "array-index": "^1.0.0"
@@ -7194,7 +7638,8 @@
                   "dependencies": {
                     "array-index": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
+                      "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
                       "dev": true,
                       "requires": {
                         "debug": "^2.2.0",
@@ -7203,7 +7648,8 @@
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
                           "dev": true,
                           "requires": {
                             "ms": "0.7.1"
@@ -7211,14 +7657,16 @@
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
                               "dev": true
                             }
                           }
                         },
                         "es6-symbol": {
                           "version": "3.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+                          "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
                           "dev": true,
                           "requires": {
                             "d": "~0.1.1",
@@ -7227,7 +7675,8 @@
                           "dependencies": {
                             "d": {
                               "version": "0.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                              "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
                               "dev": true,
                               "requires": {
                                 "es5-ext": "~0.10.2"
@@ -7235,7 +7684,8 @@
                             },
                             "es5-ext": {
                               "version": "0.10.12",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+                              "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
                               "dev": true,
                               "requires": {
                                 "es6-iterator": "2",
@@ -7244,7 +7694,8 @@
                               "dependencies": {
                                 "es6-iterator": {
                                   "version": "2.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
                                   "dev": true,
                                   "requires": {
                                     "d": "^0.1.1",
@@ -7264,7 +7715,8 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
                 "abbrev": "1"
@@ -7272,12 +7724,13 @@
             },
             "normalize-git-url": {
               "version": "3.0.2",
-              "bundled": true,
+              "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -7288,7 +7741,8 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "requires": {
                     "builtin-modules": "^1.0.0"
@@ -7296,7 +7750,8 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                       "dev": true
                     }
                   }
@@ -7305,12 +7760,13 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "dev": true
             },
             "npm-install-checks": {
               "version": "3.0.0",
-              "bundled": true,
+              "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
               "dev": true,
               "requires": {
                 "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -7318,7 +7774,8 @@
             },
             "npm-package-arg": {
               "version": "4.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
+              "integrity": "sha1-gJvGHKv1S9X/lPYWXIm6juiMEVw=",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.5",
@@ -7327,7 +7784,8 @@
             },
             "npm-registry-client": {
               "version": "7.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+              "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.2",
@@ -7344,7 +7802,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                  "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.1",
@@ -7354,7 +7813,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -7367,41 +7827,40 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "bundled": true,
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "bundled": true,
                           "dev": true
                         }
                       }
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
                 },
                 "npmlog": {
                   "version": "3.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
+                  "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
                   "dev": true,
                   "optional": true,
                   "requires": {
@@ -7413,7 +7872,8 @@
                   "dependencies": {
                     "are-we-there-yet": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                      "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -7423,7 +7883,8 @@
                       "dependencies": {
                         "delegates": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                           "dev": true,
                           "optional": true
                         }
@@ -7431,13 +7892,15 @@
                     },
                     "console-control-strings": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                       "dev": true,
                       "optional": true
                     },
                     "gauge": {
                       "version": "2.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                      "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -7454,25 +7917,29 @@
                       "dependencies": {
                         "has-color": {
                           "version": "0.1.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                          "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
                           "dev": true,
                           "optional": true
                         },
                         "object-assign": {
                           "version": "4.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
                           "dev": true,
                           "optional": true
                         },
                         "signal-exit": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                          "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
                           "dev": true,
                           "optional": true
                         },
                         "string-width": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -7483,7 +7950,8 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                              "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -7492,7 +7960,8 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                                   "dev": true,
                                   "optional": true
                                 }
@@ -7500,7 +7969,8 @@
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                               "dev": true,
                               "optional": true,
                               "requires": {
@@ -7509,7 +7979,8 @@
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                                   "dev": true,
                                   "optional": true
                                 }
@@ -7519,7 +7990,8 @@
                         },
                         "wide-align": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -7530,7 +8002,8 @@
                     },
                     "set-blocking": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                       "dev": true,
                       "optional": true
                     }
@@ -7538,19 +8011,22 @@
                 },
                 "retry": {
                   "version": "0.10.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+                  "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
                   "dev": true
                 }
               }
             },
             "npm-user-validate": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+              "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
               "dev": true
             },
             "npmlog": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+              "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
               "dev": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
@@ -7561,7 +8037,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
                   "requires": {
                     "delegates": "^1.0.0",
@@ -7570,19 +8047,22 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true
                     }
                   }
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                   "dev": true
                 },
                 "gauge": {
                   "version": "2.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                  "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
                   "dev": true,
                   "requires": {
                     "aproba": "^1.0.3",
@@ -7598,22 +8078,26 @@
                   "dependencies": {
                     "has-color": {
                       "version": "0.1.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
                       "dev": true
                     },
                     "object-assign": {
                       "version": "4.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
                       "dev": true
                     },
                     "signal-exit": {
                       "version": "3.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
+                      "integrity": "sha1-PAVDtl17T7xgts2UWT2b9DZzm+g=",
                       "dev": true
                     },
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
@@ -7623,7 +8107,8 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
@@ -7631,14 +8116,16 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                               "dev": true
                             }
                           }
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "^1.0.0"
@@ -7646,7 +8133,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
                               "dev": true
                             }
                           }
@@ -7655,7 +8143,8 @@
                     },
                     "wide-align": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
                       "dev": true,
                       "requires": {
                         "string-width": "^1.0.1"
@@ -7665,14 +8154,16 @@
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 }
               }
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -7680,12 +8171,14 @@
             },
             "opener": {
               "version": "1.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.2.tgz",
+              "integrity": "sha1-syWCCABCr4aAw4mkmRdbTFT/9SM=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
               "dev": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -7694,24 +8187,28 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
                   "dev": true
                 }
               }
             },
             "path-is-inside": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
                 "mute-stream": "~0.0.4"
@@ -7719,14 +8216,16 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
                   "dev": true
                 }
               }
             },
             "read-cmd-shim": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+              "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2"
@@ -7734,7 +8233,8 @@
             },
             "read-installed": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -7748,14 +8248,16 @@
               "dependencies": {
                 "util-extend": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+                  "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+              "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
               "dev": true,
               "requires": {
                 "glob": "^6.0.0",
@@ -7766,7 +8268,8 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
                     "inflight": "^1.0.4",
@@ -7778,7 +8281,8 @@
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                       "dev": true,
                       "requires": {
                         "brace-expansion": "^1.0.0"
@@ -7786,7 +8290,8 @@
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                           "dev": true,
                           "requires": {
                             "balanced-match": "^0.4.1",
@@ -7795,12 +8300,12 @@
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                               "dev": true
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "bundled": true,
                               "dev": true
                             }
                           }
@@ -7809,14 +8314,14 @@
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "bundled": true,
                       "dev": true
                     }
                   }
                 },
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "requires": {
                     "jju": "^1.1.0"
@@ -7824,7 +8329,8 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "dev": true
                     }
                   }
@@ -7833,7 +8339,8 @@
             },
             "read-package-tree": {
               "version": "5.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
+              "integrity": "sha1-rOfmOBx2hPlwqqmPx8XStmat2rY=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -7845,7 +8352,8 @@
             },
             "readable-stream": {
               "version": "2.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
               "dev": true,
               "requires": {
                 "buffer-shims": "^1.0.0",
@@ -7859,39 +8367,42 @@
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
                   "dev": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "bundled": true,
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true
                 }
               }
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+              "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -7902,7 +8413,7 @@
             },
             "realize-package-specifier": {
               "version": "3.0.3",
-              "bundled": true,
+              "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
               "dev": true,
               "requires": {
                 "dezalgo": "^1.0.1",
@@ -7911,7 +8422,8 @@
             },
             "request": {
               "version": "2.75.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+              "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
               "dev": true,
               "requires": {
                 "aws-sign2": "~0.6.0",
@@ -7939,17 +8451,20 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+                  "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
                   "dev": true
                 },
                 "bl": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "~2.0.5"
@@ -7957,7 +8472,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -7970,27 +8486,32 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                           "dev": true
                         }
                       }
@@ -7999,12 +8520,14 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
@@ -8012,19 +8535,28 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "dev": true
+                },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true
                 },
                 "form-data": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+                  "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
                   "dev": true,
                   "requires": {
                     "asynckit": "^0.4.0",
@@ -8034,14 +8566,16 @@
                   "dependencies": {
                     "asynckit": {
                       "version": "0.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "2.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                   "dev": true,
                   "requires": {
                     "chalk": "^1.1.1",
@@ -8052,7 +8586,8 @@
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                       "dev": true,
                       "requires": {
                         "ansi-styles": "^2.2.1",
@@ -8064,17 +8599,20 @@
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                           "dev": true
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                           "dev": true
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "^2.0.0"
@@ -8082,14 +8620,16 @@
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                           "dev": true
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                       "dev": true,
                       "requires": {
                         "graceful-readlink": ">= 1.0.0"
@@ -8097,14 +8637,16 @@
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
                           "dev": true
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.15.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
                       "dev": true,
                       "requires": {
                         "generate-function": "^2.0.0",
@@ -8115,12 +8657,14 @@
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
                           "dev": true
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                           "dev": true,
                           "requires": {
                             "is-property": "^1.0.0"
@@ -8128,26 +8672,30 @@
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
                               "dev": true
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "4.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                          "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
                           "dev": true
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                           "dev": true
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
                         "pinkie": "^2.0.0"
@@ -8155,7 +8703,8 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                           "dev": true
                         }
                       }
@@ -8164,7 +8713,8 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x",
@@ -8175,7 +8725,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -8183,7 +8734,8 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
                         "boom": "2.x.x"
@@ -8191,12 +8743,14 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -8206,7 +8760,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "^0.2.0",
@@ -8216,12 +8771,14 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2",
@@ -8231,17 +8788,20 @@
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -8251,7 +8811,8 @@
                     },
                     "sshpk": {
                       "version": "1.10.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                      "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
                       "dev": true,
                       "requires": {
                         "asn1": "~0.2.3",
@@ -8267,17 +8828,20 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "bcrypt-pbkdf": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -8286,7 +8850,8 @@
                         },
                         "dashdash": {
                           "version": "1.14.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -8294,7 +8859,8 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -8303,7 +8869,8 @@
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -8311,7 +8878,8 @@
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -8320,13 +8888,15 @@
                         },
                         "jsbn": {
                           "version": "0.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.14.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
                           "dev": true,
                           "optional": true
                         }
@@ -8336,22 +8906,26 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.12",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
                   "dev": true,
                   "requires": {
                     "mime-db": "~1.24.0"
@@ -8359,51 +8933,60 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
                       "dev": true
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
                   "dev": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                  "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
                   "dev": true
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+              "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
               "dev": true
             },
             "rimraf": {
               "version": "2.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -8411,12 +8994,14 @@
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8425,17 +9010,20 @@
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+              "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -8443,7 +9031,8 @@
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "*",
@@ -8453,7 +9042,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                  "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.0"
@@ -8463,22 +9053,26 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "dev": true
             },
             "unique-filename": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+              "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
               "dev": true,
               "requires": {
                 "unique-slug": "^2.0.0"
@@ -8486,7 +9080,7 @@
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                   "dev": true,
                   "requires": {
                     "imurmurhash": "^0.1.4"
@@ -8496,12 +9090,14 @@
             },
             "unpipe": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
                 "spdx-correct": "~1.0.0",
@@ -8510,7 +9106,8 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "requires": {
                     "spdx-license-ids": "^1.0.2"
@@ -8518,14 +9115,16 @@
                   "dependencies": {
                     "spdx-license-ids": {
                       "version": "1.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
+                      "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
                       "dev": true
                     }
                   }
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                  "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                   "dev": true,
                   "requires": {
                     "spdx-exceptions": "^1.0.4",
@@ -8534,12 +9133,12 @@
                   "dependencies": {
                     "spdx-exceptions": {
                       "version": "1.0.4",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                      "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                       "dev": true
                     },
                     "spdx-license-ids": {
                       "version": "1.2.0",
-                      "bundled": true,
                       "dev": true
                     }
                   }
@@ -8548,7 +9147,8 @@
             },
             "validate-npm-package-name": {
               "version": "2.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
+              "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
               "dev": true,
               "requires": {
                 "builtins": "0.0.7"
@@ -8556,14 +9156,16 @@
               "dependencies": {
                 "builtins": {
                   "version": "0.0.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+                  "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
               "dev": true,
               "requires": {
                 "isexe": "^1.1.1"
@@ -8571,19 +9173,22 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+              "integrity": "sha1-FMZtTkyzygVlwozzt6bz5NWTj6s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8610,6 +9215,15 @@
               "dev": true
             }
           }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
         }
       }
     },
@@ -8631,23 +9245,23 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
+            "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "supports-color": "^5.3.0"
           }
         },
         "load-json-file": {
@@ -8662,6 +9276,15 @@
             "strip-bom": "^3.0.0"
           }
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -8670,6 +9293,12 @@
           "requires": {
             "pify": "^2.0.0"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -8682,19 +9311,13 @@
             "path-type": "^2.0.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -8799,37 +9422,40 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
               "dev": true
             },
             "ansi": {
               "version": "0.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+              "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
               "dev": true
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
               "dev": true
             },
             "ansicolors": {
               "version": "0.3.2",
-              "bundled": true,
               "dev": true
             },
             "ansistyles": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
               "dev": true
             },
             "archy": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
               "dev": true
             },
             "async-some": {
               "version": "1.0.2",
-              "bundled": true,
+              "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
               "dev": true,
               "requires": {
                 "dezalgo": "^1.0.2"
@@ -8837,7 +9463,8 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.0"
@@ -8845,22 +9472,26 @@
             },
             "char-spinner": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+              "integrity": "sha1-5upnvSR+EHESmDt6sEee02KAAIE=",
               "dev": true
             },
             "chmodr": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+              "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk=",
               "dev": true
             },
             "chownr": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+              "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
               "dev": true
             },
             "cmd-shim": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+              "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8869,7 +9500,8 @@
             },
             "columnify": {
               "version": "1.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+              "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
               "dev": true,
               "requires": {
                 "strip-ansi": "^3.0.0",
@@ -8878,7 +9510,8 @@
               "dependencies": {
                 "wcwidth": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+                  "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
                   "dev": true,
                   "requires": {
                     "defaults": "^1.0.0"
@@ -8886,7 +9519,8 @@
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                       "dev": true,
                       "requires": {
                         "clone": "^1.0.2"
@@ -8894,7 +9528,8 @@
                       "dependencies": {
                         "clone": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                           "dev": true
                         }
                       }
@@ -8905,7 +9540,8 @@
             },
             "config-chain": {
               "version": "1.1.10",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+              "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
               "dev": true,
               "requires": {
                 "ini": "^1.3.4",
@@ -8914,14 +9550,15 @@
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                  "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                   "dev": true
                 }
               }
             },
             "dezalgo": {
               "version": "1.0.3",
-              "bundled": true,
+              "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
                 "asap": "^2.0.0",
@@ -8930,19 +9567,22 @@
               "dependencies": {
                 "asap": {
                   "version": "2.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
+                  "integrity": "sha1-H8HRVk7hFiDfym1nAphQkT+fRnk=",
                   "dev": true
                 }
               }
             },
             "editor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+              "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
               "dev": true
             },
             "fs-vacuum": {
               "version": "1.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
+              "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8952,7 +9592,8 @@
             },
             "fs-write-stream-atomic": {
               "version": "1.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
+              "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8963,14 +9604,15 @@
               "dependencies": {
                 "iferr": {
                   "version": "0.1.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+                  "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                   "dev": true
                 }
               }
             },
             "fstream": {
               "version": "1.0.10",
-              "bundled": true,
+              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8981,7 +9623,8 @@
             },
             "fstream-npm": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
+              "integrity": "sha1-a5F122I5qD2CCeIyQmxJTbspaQw=",
               "dev": true,
               "requires": {
                 "fstream-ignore": "^1.0.0",
@@ -8990,7 +9633,8 @@
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
                   "dev": true,
                   "requires": {
                     "fstream": "^1.0.0",
@@ -9002,17 +9646,19 @@
             },
             "github-url-from-git": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
+              "integrity": "sha1-KF5rUggZABveEoZ0cEN55P8D4N4=",
               "dev": true
             },
             "github-url-from-username-repo": {
               "version": "1.0.2",
-              "bundled": true,
+              "integrity": "sha1-fdeTMNKr5pwQws73lxTJchV5Hfo=",
               "dev": true
             },
             "glob": {
               "version": "7.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -9025,34 +9671,40 @@
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                   "dev": true
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                   "dev": true
                 }
               }
             },
             "graceful-fs": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+              "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
               "dev": true
             },
             "hosted-git-info": {
               "version": "2.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+              "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
               "dev": true
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
               "dev": true
             },
             "inflight": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
                 "once": "^1.3.0",
@@ -9061,17 +9713,20 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true
             },
             "init-package-json": {
               "version": "1.9.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
+              "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
               "dev": true,
               "requires": {
                 "glob": "^6.0.0",
@@ -9086,7 +9741,8 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
                     "inflight": "^1.0.4",
@@ -9098,14 +9754,16 @@
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                       "dev": true
                     }
                   }
                 },
                 "promzard": {
                   "version": "0.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                  "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                   "dev": true,
                   "requires": {
                     "read": "1"
@@ -9115,12 +9773,14 @@
             },
             "lockfile": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+              "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU=",
               "dev": true
             },
             "lru-cache": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+              "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.1",
@@ -9129,19 +9789,22 @@
               "dependencies": {
                 "pseudomap": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                   "dev": true
                 },
                 "yallist": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+                  "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
                   "dev": true
                 }
               }
             },
             "minimatch": {
               "version": "3.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
               "dev": true,
               "requires": {
                 "brace-expansion": "^1.0.0"
@@ -9149,7 +9812,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "^0.4.1",
@@ -9158,12 +9822,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -9172,7 +9838,8 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -9180,14 +9847,16 @@
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                   "dev": true
                 }
               }
             },
             "node-gyp": {
               "version": "3.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
+              "integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
               "dev": true,
               "requires": {
                 "fstream": "^1.0.0",
@@ -9207,14 +9876,15 @@
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                   "dev": true
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
                 "abbrev": "1"
@@ -9222,12 +9892,14 @@
             },
             "normalize-git-url": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
+              "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
               "dev": true
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -9238,7 +9910,8 @@
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                   "dev": true,
                   "requires": {
                     "builtin-modules": "^1.0.0"
@@ -9246,7 +9919,8 @@
                   "dependencies": {
                     "builtin-modules": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                      "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw=",
                       "dev": true
                     }
                   }
@@ -9255,12 +9929,14 @@
             },
             "npm-cache-filename": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+              "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
               "dev": true
             },
             "npm-install-checks": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
+              "integrity": "sha1-bZGu2grJaAHx7Xqt7hFqbAoIalc=",
               "dev": true,
               "requires": {
                 "npmlog": "0.1 || 1 || 2",
@@ -9269,7 +9945,8 @@
             },
             "npm-package-arg": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
+              "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
               "dev": true,
               "requires": {
                 "hosted-git-info": "^2.1.4",
@@ -9278,7 +9955,8 @@
             },
             "npm-registry-client": {
               "version": "7.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
+              "integrity": "sha1-x5ImawiMwxP4Ul5+NSSGJscj23U=",
               "dev": true,
               "requires": {
                 "concat-stream": "^1.5.2",
@@ -9295,7 +9973,8 @@
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+                  "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
                   "dev": true,
                   "requires": {
                     "inherits": "~2.0.1",
@@ -9305,7 +9984,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -9318,53 +9998,62 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                           "dev": true
                         }
                       }
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                       "dev": true
                     }
                   }
                 },
                 "retry": {
                   "version": "0.10.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+                  "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
                   "dev": true
                 }
               }
             },
             "npm-user-validate": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
+              "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
               "dev": true
             },
             "npmlog": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+              "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
               "dev": true,
               "requires": {
                 "ansi": "~0.3.1",
@@ -9374,7 +10063,8 @@
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
                   "dev": true,
                   "requires": {
                     "delegates": "^1.0.0",
@@ -9383,14 +10073,16 @@
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                       "dev": true
                     }
                   }
                 },
                 "gauge": {
                   "version": "1.2.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+                  "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
                   "dev": true,
                   "requires": {
                     "ansi": "^0.3.0",
@@ -9402,22 +10094,26 @@
                   "dependencies": {
                     "has-unicode": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                      "integrity": "sha1-o82Wwwe6QdVZxaLuQIwSoRxMLsM=",
                       "dev": true
                     },
                     "lodash._baseslice": {
                       "version": "4.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
+                      "integrity": "sha1-9c4d+YKUjsr/Y/IjhTQVt7l2NwQ=",
                       "dev": true
                     },
                     "lodash._basetostring": {
                       "version": "4.12.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+                      "integrity": "sha1-kyfJ3FFYhmt/pLnUL0Y45XZt2d8=",
                       "dev": true
                     },
                     "lodash.pad": {
                       "version": "4.4.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
+                      "integrity": "sha1-+qON8mwKaexQhqgiRslY4VDcsas=",
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "~4.0.0",
@@ -9427,7 +10123,8 @@
                     },
                     "lodash.padend": {
                       "version": "4.5.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
+                      "integrity": "sha1-oonpN37i5t6Lp/EfOo6zJgcLdhk=",
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "~4.0.0",
@@ -9437,7 +10134,8 @@
                     },
                     "lodash.padstart": {
                       "version": "4.5.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
+                      "integrity": "sha1-PqGQ9nNIQcM2TSedEeBWcmtgp5o=",
                       "dev": true,
                       "requires": {
                         "lodash._baseslice": "~4.0.0",
@@ -9447,7 +10145,8 @@
                     },
                     "lodash.tostring": {
                       "version": "4.1.4",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
+                      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs=",
                       "dev": true
                     }
                   }
@@ -9456,7 +10155,8 @@
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1"
@@ -9464,12 +10164,14 @@
             },
             "opener": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
+              "integrity": "sha1-iXWQrNGu0zEbcDtYvMtNQ/VvKJU=",
               "dev": true
             },
             "osenv": {
               "version": "0.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
               "dev": true,
               "requires": {
                 "os-homedir": "^1.0.0",
@@ -9478,24 +10180,27 @@
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
+                  "integrity": "sha1-43B4vGG1hpBjBTiXJX457BJhtwI=",
                   "dev": true
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24=",
                   "dev": true
                 }
               }
             },
             "path-is-inside": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
               "dev": true
             },
             "read": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
               "dev": true,
               "requires": {
                 "mute-stream": "~0.0.4"
@@ -9503,14 +10208,15 @@
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
                   "dev": true
                 }
               }
             },
             "read-installed": {
               "version": "4.0.3",
-              "bundled": true,
+              "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
                 "debuglog": "^1.0.1",
@@ -9524,12 +10230,13 @@
               "dependencies": {
                 "debuglog": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+                  "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
                   "dev": true
                 },
                 "readdir-scoped-modules": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
                   "dev": true,
                   "requires": {
                     "debuglog": "^1.0.1",
@@ -9540,14 +10247,16 @@
                 },
                 "util-extend": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
+                  "integrity": "sha1-u3A7eUgCk93Nz7PGqf6iD0g0Fbw=",
                   "dev": true
                 }
               }
             },
             "read-package-json": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+              "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
               "dev": true,
               "requires": {
                 "glob": "^6.0.0",
@@ -9558,7 +10267,8 @@
               "dependencies": {
                 "glob": {
                   "version": "6.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                   "dev": true,
                   "requires": {
                     "inflight": "^1.0.4",
@@ -9570,14 +10280,16 @@
                   "dependencies": {
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                       "dev": true
                     }
                   }
                 },
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
                   "dev": true,
                   "requires": {
                     "jju": "^1.1.0"
@@ -9585,7 +10297,8 @@
                   "dependencies": {
                     "jju": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+                      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
                       "dev": true
                     }
                   }
@@ -9594,7 +10307,8 @@
             },
             "readable-stream": {
               "version": "2.1.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
               "dev": true,
               "requires": {
                 "buffer-shims": "^1.0.0",
@@ -9608,39 +10322,46 @@
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
                   "dev": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                   "dev": true
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                   "dev": true
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                   "dev": true
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                   "dev": true
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                   "dev": true
                 }
               }
             },
             "realize-package-specifier": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
+              "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
               "dev": true,
               "requires": {
                 "dezalgo": "^1.0.1",
@@ -9649,7 +10370,8 @@
             },
             "request": {
               "version": "2.74.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+              "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
               "dev": true,
               "requires": {
                 "aws-sign2": "~0.6.0",
@@ -9677,17 +10399,20 @@
               "dependencies": {
                 "aws-sign2": {
                   "version": "0.6.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
                   "dev": true
                 },
                 "aws4": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+                  "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
                   "dev": true
                 },
                 "bl": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
                   "dev": true,
                   "requires": {
                     "readable-stream": "~2.0.5"
@@ -9695,7 +10420,8 @@
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                       "dev": true,
                       "requires": {
                         "core-util-is": "~1.0.0",
@@ -9708,27 +10434,32 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                           "dev": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                           "dev": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                           "dev": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                           "dev": true
                         }
                       }
@@ -9737,12 +10468,14 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
                   "dev": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
@@ -9750,19 +10483,28 @@
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                       "dev": true
                     }
                   }
                 },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "dev": true
+                },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                   "dev": true
                 },
                 "form-data": {
                   "version": "1.0.0-rc4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+                  "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
                   "dev": true,
                   "requires": {
                     "async": "^1.5.2",
@@ -9772,14 +10514,16 @@
                   "dependencies": {
                     "async": {
                       "version": "1.5.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                       "dev": true
                     }
                   }
                 },
                 "har-validator": {
                   "version": "2.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                   "dev": true,
                   "requires": {
                     "chalk": "^1.1.1",
@@ -9790,7 +10534,8 @@
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                       "dev": true,
                       "requires": {
                         "ansi-styles": "^2.2.1",
@@ -9802,17 +10547,20 @@
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                           "dev": true
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                           "dev": true
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "^2.0.0"
@@ -9820,14 +10568,16 @@
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                           "dev": true
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                       "dev": true,
                       "requires": {
                         "graceful-readlink": ">= 1.0.0"
@@ -9835,14 +10585,16 @@
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
                           "dev": true
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.13.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                      "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
                       "dev": true,
                       "requires": {
                         "generate-function": "^2.0.0",
@@ -9853,12 +10605,14 @@
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
                           "dev": true
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
                           "dev": true,
                           "requires": {
                             "is-property": "^1.0.0"
@@ -9866,26 +10620,30 @@
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
                               "dev": true
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
                           "dev": true
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                           "dev": true
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
                         "pinkie": "^2.0.0"
@@ -9893,7 +10651,8 @@
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
                           "dev": true
                         }
                       }
@@ -9902,7 +10661,8 @@
                 },
                 "hawk": {
                   "version": "3.1.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                   "dev": true,
                   "requires": {
                     "boom": "2.x.x",
@@ -9913,7 +10673,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -9921,7 +10682,8 @@
                     },
                     "cryptiles": {
                       "version": "2.0.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                       "dev": true,
                       "requires": {
                         "boom": "2.x.x"
@@ -9929,12 +10691,14 @@
                     },
                     "hoek": {
                       "version": "2.16.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
                       "dev": true
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                       "dev": true,
                       "requires": {
                         "hoek": "2.x.x"
@@ -9944,7 +10708,8 @@
                 },
                 "http-signature": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "^0.2.0",
@@ -9954,12 +10719,14 @@
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
                       "dev": true
                     },
                     "jsprim": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                      "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
                       "dev": true,
                       "requires": {
                         "extsprintf": "1.0.2",
@@ -9969,17 +10736,20 @@
                       "dependencies": {
                         "extsprintf": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
                           "dev": true
                         },
                         "json-schema": {
                           "version": "0.2.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
                           "dev": true
                         },
                         "verror": {
                           "version": "1.3.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
                           "dev": true,
                           "requires": {
                             "extsprintf": "1.0.2"
@@ -9989,7 +10759,8 @@
                     },
                     "sshpk": {
                       "version": "1.9.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+                      "integrity": "sha1-O0E1G7rVw03fS9gRmTfv7jGkZ2U=",
                       "dev": true,
                       "requires": {
                         "asn1": "~0.2.3",
@@ -10004,17 +10775,20 @@
                       "dependencies": {
                         "asn1": {
                           "version": "0.2.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                           "dev": true
                         },
                         "assert-plus": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                           "dev": true
                         },
                         "dashdash": {
                           "version": "1.14.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -10022,7 +10796,8 @@
                         },
                         "ecc-jsbn": {
                           "version": "0.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -10031,7 +10806,8 @@
                         },
                         "getpass": {
                           "version": "0.1.6",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
                           "dev": true,
                           "requires": {
                             "assert-plus": "^1.0.0"
@@ -10039,7 +10815,8 @@
                         },
                         "jodid25519": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
                           "dev": true,
                           "optional": true,
                           "requires": {
@@ -10048,13 +10825,15 @@
                         },
                         "jsbn": {
                           "version": "0.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                           "dev": true,
                           "optional": true
                         },
                         "tweetnacl": {
                           "version": "0.13.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
                           "dev": true,
                           "optional": true
                         }
@@ -10064,22 +10843,26 @@
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                   "dev": true
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                   "dev": true
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                   "dev": true
                 },
                 "mime-types": {
                   "version": "2.1.11",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
                   "dev": true,
                   "requires": {
                     "mime-db": "~1.23.0"
@@ -10087,51 +10870,60 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.23.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
                       "dev": true
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.7",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
                   "dev": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                   "dev": true
                 },
                 "qs": {
                   "version": "6.2.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                  "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
                   "dev": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
                   "dev": true
                 },
                 "tough-cookie": {
                   "version": "2.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
                   "dev": true
                 },
                 "tunnel-agent": {
                   "version": "0.4.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
                   "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
+              "integrity": "sha1-ZJ4VykCEItmDGBYZNef31lLUNd0=",
               "dev": true
             },
             "rimraf": {
               "version": "2.5.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
                 "glob": "^7.0.5"
@@ -10139,12 +10931,14 @@
             },
             "semver": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+              "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
               "dev": true
             },
             "sha": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -10153,7 +10947,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "integrity": "sha1-vsgb6ujPRVFovC5bKzH1vPrtmxs=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "~1.0.0",
@@ -10166,27 +10961,32 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "integrity": "sha1-awcIWu+aPMrG7lO/nT3wwVIaVTg=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                       "dev": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                      "integrity": "sha1-4nLu2CXV6fTqdNjXOx/jEcO+tjA=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                      "integrity": "sha1-NVaj0TxMaqeYPX4kJUeBlxmbeIE=",
                       "dev": true
                     }
                   }
@@ -10195,22 +10995,26 @@
             },
             "slide": {
               "version": "1.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+              "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
               "dev": true
             },
             "sorted-object": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
+              "integrity": "sha1-HP6pgWCQR9gEOAekkKnZmzF/r38=",
               "dev": true
             },
             "spdx-license-ids": {
               "version": "1.2.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -10218,7 +11022,7 @@
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "*",
@@ -10228,22 +11032,24 @@
             },
             "text-table": {
               "version": "0.2.0",
-              "bundled": true,
               "dev": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true
             },
             "umask": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+              "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
               "dev": true
             },
             "validate-npm-package-license": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
                 "spdx-correct": "~1.0.0",
@@ -10252,7 +11058,8 @@
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                   "dev": true,
                   "requires": {
                     "spdx-license-ids": "^1.0.2"
@@ -10260,7 +11067,8 @@
                 },
                 "spdx-expression-parse": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                  "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                   "dev": true,
                   "requires": {
                     "spdx-exceptions": "^1.0.4",
@@ -10269,7 +11077,8 @@
                   "dependencies": {
                     "spdx-exceptions": {
                       "version": "1.0.4",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                      "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
                       "dev": true
                     }
                   }
@@ -10278,7 +11087,7 @@
             },
             "validate-npm-package-name": {
               "version": "2.2.2",
-              "bundled": true,
+              "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
               "dev": true,
               "requires": {
                 "builtins": "0.0.7"
@@ -10286,14 +11095,14 @@
               "dependencies": {
                 "builtins": {
                   "version": "0.0.7",
-                  "bundled": true,
                   "dev": true
                 }
               }
             },
             "which": {
               "version": "1.2.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
               "dev": true,
               "requires": {
                 "isexe": "^1.1.1"
@@ -10301,19 +11110,21 @@
               "dependencies": {
                 "isexe": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
                   "dev": true
                 }
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             },
             "write-file-atomic": {
               "version": "1.1.4",
-              "bundled": true,
+              "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -10332,9 +11143,9 @@
       }
     },
     "nth-check": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dev": true,
       "requires": {
         "boolbase": "~1.0.0"
@@ -10347,9 +11158,9 @@
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -10358,10 +11169,26 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object.assign": {
@@ -10374,6 +11201,18 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -10398,30 +11237,38 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-homedir": {
@@ -10443,9 +11290,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -10476,9 +11323,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "dev": true,
       "requires": {
         "character-entities": "^1.0.0",
@@ -10490,12 +11337,12 @@
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -10508,13 +11355,9 @@
       }
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -10535,10 +11378,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-glob-pattern": {
       "version": "1.0.2",
@@ -10547,14 +11389,11 @@
       "dev": true
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pause-stream": {
@@ -10595,12 +11434,6 @@
         "which": "^1.2.10"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -10630,10 +11463,9 @@
       }
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -10670,40 +11502,32 @@
       }
     },
     "power-assert-context-formatter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
-      "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
+      "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
-        "power-assert-context-traversal": "^1.1.1"
+        "power-assert-context-traversal": "^1.2.0"
       }
     },
     "power-assert-context-reducer-ast": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
-      "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
+      "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.0",
+        "acorn": "^5.0.0",
         "acorn-es7-plugin": "^1.0.12",
         "core-js": "^2.0.0",
         "espurify": "^1.6.0",
         "estraverse": "^4.2.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
       }
     },
     "power-assert-context-traversal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
-      "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
+      "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -10726,13 +11550,13 @@
       }
     },
     "power-assert-renderer-assertion": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
-      "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
+      "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1"
+        "power-assert-util-string-width": "^1.2.0"
       }
     },
     "power-assert-renderer-base": {
@@ -10742,9 +11566,9 @@
       "dev": true
     },
     "power-assert-renderer-comparison": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
-      "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
+      "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -10755,33 +11579,33 @@
       }
     },
     "power-assert-renderer-diagram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
-      "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
+      "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
         "power-assert-renderer-base": "^1.1.1",
-        "power-assert-util-string-width": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0",
         "stringifier": "^1.3.0"
       }
     },
     "power-assert-renderer-file": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
-      "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
+      "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
       "dev": true,
       "requires": {
         "power-assert-renderer-base": "^1.1.1"
       }
     },
     "power-assert-util-string-width": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
-      "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
+      "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
       "dev": true,
       "requires": {
-        "eastasianwidth": "^0.1.1"
+        "eastasianwidth": "^0.2.0"
       }
     },
     "prelude-ls": {
@@ -10813,30 +11637,51 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+    "property-information": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
+      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
       "dev": true,
       "requires": {
-        "event-stream": "~3.3.0"
+        "xtend": "^4.0.0"
+      }
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
       }
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "q": {
@@ -10860,9 +11705,9 @@
       }
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
       "dev": true
     },
     "quick-lru": {
@@ -10880,55 +11725,77 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      }
+    },
+    "rc-config-loader": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.5.tgz",
+      "integrity": "sha512-T464K2MQlnNWOblUDIglpFhyN+zYJq7jSlL++/N0hUkcmIXeNFumwXFVdtf8qhUGohn4RYQ0wdi74R575I44PQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "js-yaml": "^3.12.0",
+        "json5": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "object-keys": "^1.0.12",
+        "path-exists": "^3.0.0",
+        "require-from-string": "^2.0.2"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
-    "rc-config-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.1.tgz",
-      "integrity": "sha512-OHr24Jb7nN6oaQOTRXxcQ2yJSK3SHA1dp2CZEfvRxsl/MbhFr4CYnkwn8DY37pKu7Eu18X4mYuWFxO6vpbFxtQ==",
-      "dev": true,
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "debug": "^2.2.0",
-        "js-yaml": "^3.6.1",
-        "json5": "^0.5.0",
-        "object-assign": "^4.1.0",
-        "object-keys": "^1.0.9",
-        "path-exists": "^2.1.0",
-        "require-from-string": "^2.0.1"
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redent": {
@@ -10941,9 +11808,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+      "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -10964,12 +11831,13 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpp": {
@@ -11036,6 +11904,25 @@
       "resolved": "https://registry.npmjs.org/regx/-/regx-1.0.4.tgz",
       "integrity": "sha1-oO4ywwiRCQIBnKERftQbnd0EGy8=",
       "dev": true
+    },
+    "rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "dev": true,
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+          "dev": true
+        }
+      }
     },
     "remark": {
       "version": "7.0.1",
@@ -11116,31 +12003,39 @@
       "dev": true
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
+        "aws4": "^1.8.0",
         "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
       }
     },
     "request-progress": {
@@ -11153,9 +12048,9 @@
       }
     },
     "require-from-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
-      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-uncached": {
@@ -11169,12 +12064,11 @@
       }
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -11194,22 +12088,19 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -11227,9 +12118,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safer-buffer": {
@@ -11239,9 +12130,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -11284,21 +12175,15 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
-      "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
-      }
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "slash": {
       "version": "1.0.0",
@@ -11307,12 +12192,12 @@
       "dev": true
     },
     "sleep": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/sleep/-/sleep-5.1.1.tgz",
-      "integrity": "sha1-h4+h1E0I7rDyb7IBjvhinrGjq5Q=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/sleep/-/sleep-6.3.0.tgz",
+      "integrity": "sha512-+WgYl951qdUlb1iS97UvQ01pkauoBK9ML9I/CMPg41v0Ze4EyMlTgFTDDo32iYj98IYqxIjDMRd+L71lawFfpQ==",
       "dev": true,
       "requires": {
-        "nan": ">=2.5.1"
+        "nan": "^2.14.1"
       }
     },
     "slice-ansi": {
@@ -11325,9 +12210,9 @@
       }
     },
     "sorted-array": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-2.0.2.tgz",
-      "integrity": "sha512-5PJPU+PRic0yPU94+YCtokdmasqJ7kLCMg83CIus5yjkeGjYQkxX1X49/71/sgqvtGLpt9Wh+gnKdBOYWzG/9w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-2.0.4.tgz",
+      "integrity": "sha512-58INzrX0rL6ttCfsGoFmOuQY5AjR6A5E/MmGKJ5JvWHOey6gOEOC6vO8K6C0Y2bQR6KJ8o8aFwHjp/mJ/HcYsQ==",
       "dev": true
     },
     "sorted-joyo-kanji": {
@@ -11343,10 +12228,9 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.4.18",
@@ -11355,7 +12239,21 @@
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
+    },
+    "space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true
     },
     "spawn-please": {
       "version": "0.3.0",
@@ -11364,22 +12262,32 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+    },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "split": {
       "version": "0.3.3",
@@ -11397,9 +12305,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -11409,6 +12317,7 @@
         "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
         "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
     },
@@ -11418,9 +12327,9 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "state-toggle": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
-      "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
     },
     "stream-combiner": {
@@ -11460,40 +12369,66 @@
       }
     },
     "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.padstart": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
-      "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.1.0.tgz",
+      "integrity": "sha512-envqZvUp2JItI+OeQ5UAh1ihbAV5G/2bixTojvlIa090GGqF+NQRxbWb2nv9fTGrZABv6+pE6jXoAZhhS2k4Hw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "stringifier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
-      "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.4.0.tgz",
+      "integrity": "sha512-cNsMOqqrcbLcHTXEVmkw9y0fwDwkdgtZwlfyolzpQDoAE1xdNGhQhxBUfiDvvZIKl1hnUEgMv66nHwtMz3OjPw==",
       "dev": true,
       "requires": {
         "core-js": "^2.0.0",
@@ -11502,9 +12437,9 @@
       }
     },
     "stringify-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
-      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "dev": true,
       "requires": {
         "character-entities-html4": "^1.0.0",
@@ -11523,13 +12458,9 @@
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -11597,9 +12528,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11607,16 +12538,10 @@
             "supports-color": "^5.3.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -11694,6 +12619,56 @@
             "number-is-nan": "^1.0.0"
           }
         },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11703,6 +12678,15 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -11845,12 +12829,23 @@
       }
     },
     "textlint-rule-helper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.0.0.tgz",
-      "integrity": "sha1-lctGlslcQljS4zienmS4SflyE4I=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+      "integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
       "dev": true,
       "requires": {
+        "@textlint/ast-node-types": "^4.2.1",
+        "@textlint/types": "^1.1.2",
+        "structured-source": "^3.0.2",
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
+          "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
+          "dev": true
+        }
       }
     },
     "textlint-rule-incremental-headers": {
@@ -11860,33 +12855,33 @@
       "dev": true
     },
     "textlint-rule-max-ten": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-2.0.3.tgz",
-      "integrity": "sha1-3MvA0BV+6Gp1csoApHqx+ld/BkU=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/textlint-rule-max-ten/-/textlint-rule-max-ten-2.0.4.tgz",
+      "integrity": "sha512-jpAo7+afIhZiegsAcD8PB22px1bqdkN3VAkPHijZsZlB05+Z1rZS/SCoUtgT+5NveErk+Bbcmm4jOLo+owq6+Q==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.0.2",
+        "kuromojin": "^2.0.0",
         "sentence-splitter": "^2.0.0",
         "structured-source": "^3.0.2",
         "textlint-rule-helper": "^2.0.0"
       }
     },
     "textlint-rule-no-double-negative-ja": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-double-negative-ja/-/textlint-rule-no-double-negative-ja-1.0.5.tgz",
-      "integrity": "sha1-ujDbQk3H74TO2m0QN4GxTNIMx2Q=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-double-negative-ja/-/textlint-rule-no-double-negative-ja-1.0.6.tgz",
+      "integrity": "sha512-pwEn/3CMRE1Md3de3+WKd+R0ZD0luxGAAw5D+OrPgvjp9mE5VSL1pNt2rUqZV1+NBtUE4EcxZPdCw1QHTLmslg==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.1.0"
+        "kuromojin": "^2.0.0"
       }
     },
     "textlint-rule-no-doubled-conjunction": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-1.0.2.tgz",
-      "integrity": "sha1-JMboAUxrLhhLx6XUwabuE7swmTA=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunction/-/textlint-rule-no-doubled-conjunction-1.0.3.tgz",
+      "integrity": "sha512-0YRPG6daaGXI0sq1RLNry7rzk2HKJbTOB5dohR0+GQ60r+Fc8RKRo+auCPRu6RIYZOD65AApemLpiaMbrgucDQ==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.1.0",
+        "kuromojin": "^2.0.0",
         "sentence-splitter": "^2.0.0",
         "textlint-rule-helper": "^1.1.5",
         "textlint-util-to-string": "^1.2.0"
@@ -11904,12 +12899,12 @@
       }
     },
     "textlint-rule-no-doubled-conjunctive-particle-ga": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-1.0.2.tgz",
-      "integrity": "sha1-uctnlVWuoqsNT/z6TdL/q3G/AFc=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-conjunctive-particle-ga/-/textlint-rule-no-doubled-conjunctive-particle-ga-1.1.1.tgz",
+      "integrity": "sha512-UvjKadrYOvA5F9rkCk5YafmEyxgdwJEZoz/MHCWhNFnTSDBryhIL986qxeZAjI/4FB9mZUDxQsDph2W7Sn8acA==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.1.0",
+        "kuromojin": "^2.0.0",
         "sentence-splitter": "^1.2.0",
         "textlint-rule-helper": "^1.1.5",
         "textlint-util-to-string": "^1.2.0"
@@ -11936,47 +12931,127 @@
       }
     },
     "textlint-rule-no-doubled-joshi": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-3.5.1.tgz",
-      "integrity": "sha1-dZxsXe+AdfhJ2aTfVRwtKggVui8=",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-doubled-joshi/-/textlint-rule-no-doubled-joshi-3.7.2.tgz",
+      "integrity": "sha512-6du7XciMGZuvAdEL0vAA7JSXVS9NbtWwsbVCeJ8ynSl4hNI+g9tGeN6zYZARJD6/cyklP+zFSvXixKf6nFFqMA==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.2.1",
-        "sentence-splitter": "^2.2.0",
-        "textlint-rule-helper": "^1.1.4",
-        "textlint-util-to-string": "^1.1.0"
+        "kuromojin": "^2.0.0",
+        "sentence-splitter": "^3.2.0",
+        "textlint-rule-helper": "^2.1.1",
+        "textlint-util-to-string": "^3.0.0"
       },
       "dependencies": {
-        "textlint-rule-helper": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+        "@textlint/ast-node-types": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
+          "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "dev": true,
           "requires": {
-            "unist-util-visit": "^1.1.0"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "sentence-splitter": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.0.tgz",
+          "integrity": "sha512-lKX2tZ1rsA9Tu0gW8vRmMDmIEJoZ1d7cKpzcbFZdUrSpCR6gy/7OPPh7jjT/6Oc6Z79ToUmC2l8tyTEGanVmiA==",
+          "dev": true,
+          "requires": {
+            "@textlint/ast-node-types": "^4.2.5",
+            "concat-stream": "^2.0.0",
+            "object.values": "^1.1.0",
+            "structured-source": "^3.0.2"
+          }
+        },
+        "textlint-util-to-string": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.1.1.tgz",
+          "integrity": "sha512-mHE7/pDw/Hk+Q6YdSMNRrZPl5bCuWnFLbF+bxW+MsWQ64dw+Ia9irkammYbH5I0hVMMcfwb0MQc5nbsjqgWeyQ==",
+          "dev": true,
+          "requires": {
+            "@textlint/ast-node-types": "^4.2.4",
+            "@types/structured-source": "^3.0.0",
+            "rehype-parse": "^6.0.1",
+            "structured-source": "^3.0.2",
+            "unified": "^8.4.0"
+          }
+        },
+        "unified": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+          "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        },
+        "vfile": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+          "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
           }
         }
       }
     },
     "textlint-rule-no-dropping-the-ra": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-dropping-the-ra/-/textlint-rule-no-dropping-the-ra-1.1.2.tgz",
-      "integrity": "sha1-F9jGWYbXvYAUpFKTA6K6C3aaidI=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-dropping-the-ra/-/textlint-rule-no-dropping-the-ra-1.1.3.tgz",
+      "integrity": "sha512-JYCFIxiuX86aQZaS0McfVEJugu7EoqTtgTPIw5w/oB3htJb2SIFrLnX7Y017+IOsg7mu+bjH5Zko7H62xD2slg==",
       "dev": true,
       "requires": {
-        "kuromojin": "^1.2.1",
-        "textlint-rule-helper": "^1.1.4"
-      },
-      "dependencies": {
-        "textlint-rule-helper": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
-          "dev": true,
-          "requires": {
-            "unist-util-visit": "^1.1.0"
-          }
-        }
+        "kuromojin": "^2.0.0",
+        "textlint-rule-helper": "^2.1.1"
       }
     },
     "textlint-rule-no-mix-dearu-desumasu": {
@@ -11991,25 +13066,14 @@
       }
     },
     "textlint-rule-no-nfd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.1.tgz",
-      "integrity": "sha1-v0g/hE5kHvI64/gjYUIanlO11lo=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-no-nfd/-/textlint-rule-no-nfd-1.0.2.tgz",
+      "integrity": "sha512-n6tUx40/V6koDo78qqePHxSovuwSIKO0xwY3FCqVDbcfg9GxQCjde1twQJ99T3bs4LabhPOo/Pt3USaQ9XcTRQ==",
       "dev": true,
       "requires": {
-        "match-index": "^1.0.1",
-        "textlint-rule-helper": "^1.1.5",
+        "match-index": "^1.0.3",
+        "textlint-rule-helper": "^2.1.1",
         "unorm": "^1.4.1"
-      },
-      "dependencies": {
-        "textlint-rule-helper": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-          "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
-          "dev": true,
-          "requires": {
-            "unist-util-visit": "^1.1.0"
-          }
-        }
       }
     },
     "textlint-rule-preset-japanese": {
@@ -12079,14 +13143,20 @@
         "untildify": "^3.0.2"
       },
       "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
         "prh": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.3.tgz",
-          "integrity": "sha512-W5+gzqOrVLKayPh+2QCur7KYZPsLRfDJd4Tyz5lIXAWwqaX/LQ40FX/P3/Hbfgf7w+EQPdR1yOx6BVf+frG40w==",
+          "version": "5.4.4",
+          "resolved": "https://registry.npmjs.org/prh/-/prh-5.4.4.tgz",
+          "integrity": "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw==",
           "dev": true,
           "requires": {
             "commandpost": "^1.2.1",
-            "diff": "^3.3.0",
+            "diff": "^4.0.1",
             "js-yaml": "^3.9.1"
           }
         }
@@ -12165,20 +13235,13 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "traverse": {
@@ -12205,15 +13268,15 @@
       "dev": true
     },
     "trim-trailing-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
       "dev": true
     },
     "trough": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
-      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "try-resolve": {
@@ -12235,8 +13298,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "txt-ast-traverse": {
       "version": "1.2.1",
@@ -12274,20 +13336,26 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+      "optional": true
+    },
     "unherit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "unified": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
       "dev": true,
       "requires": {
         "bail": "^1.0.0",
@@ -12295,7 +13363,6 @@
         "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
         "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4",
         "x-is-string": "^0.1.0"
       }
     },
@@ -12315,42 +13382,42 @@
       }
     },
     "unist-util-is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
-      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
       "dev": true
     },
-    "unist-util-modify-children": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.1.tgz",
-      "integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
-      "dev": true,
-      "requires": {
-        "array-iterate": "^1.0.0"
-      }
-    },
     "unist-util-remove-position": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
-      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
-      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
       "dev": true
     },
     "unist-util-visit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
-      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.1"
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
       }
     },
     "universal-deep-strict-equal": {
@@ -12362,32 +13429,24 @@
         "array-filter": "^1.0.0",
         "indexof": "0.0.1",
         "object-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "array-filter": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-          "dev": true
-        }
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unorm": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
-      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
       "dev": true
     },
     "untildify": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-      "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
       "dev": true
     },
     "unzip-response": {
@@ -12434,12 +13493,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12449,6 +13502,15 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "url-parse-lax": {
@@ -12482,18 +13544,18 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -12520,15 +13582,15 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
-      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
       "dev": true
     },
     "vfile-message": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
-      "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "dev": true,
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
@@ -12540,10 +13602,16 @@
       "integrity": "sha1-tm5Wqd8L0lp2u/G1FNsSkIBhSjc=",
       "dev": true
     },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true
+    },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -12559,9 +13627,9 @@
       }
     },
     "winston": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
-      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",
@@ -12569,13 +13637,6 @@
         "eyes": "0.1.x",
         "isstream": "0.1.x",
         "stack-trace": "0.0.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-        }
       }
     },
     "winston-color": {
@@ -12586,11 +13647,16 @@
         "winston": "^2.1.1"
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -12608,21 +13674,15 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
-    },
-    "x-is-function": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
-      "dev": true
     },
     "x-is-string": {
       "version": "0.1.0",
@@ -12643,9 +13703,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "yallist": {
@@ -12655,12 +13715,13 @@
       "dev": true
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "zlibjs": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "svgexport": "0.3.2",
     "textlint": "9.0.1",
     "textlint-rule-incremental-headers": "0.2.0",
-    "textlint-rule-preset-japanese": "2.0.0",
+    "textlint-rule-preset-japanese": "5.0.0",
     "textlint-rule-preset-jtf-style": "2.3.0",
     "textlint-rule-prh": "5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "npm-run-all": "4.1.1",
     "power-assert": "1.4.4",
     "q-io": "1.13.4",
-    "sleep": "5.1.1",
+    "sleep": "6.3.0",
     "svgexport": "0.3.2",
     "textlint": "9.0.1",
     "textlint-rule-incremental-headers": "0.2.0",

--- a/src/implicit.md
+++ b/src/implicit.md
@@ -70,8 +70,8 @@ implicit class RichString(val src: String) {
 ```
 
 という形で書きなおすことができます。
-implicit classはpimp my libraryパターン専用の機能であり、implicit defで既存型への変換した場合などによる混乱がないため、Scala 2.10以降でpimp my libraryパターンを使うときは基本的に後者の形式にすべきですが、
-サードパーティのライブラリや標準ライブラリでも前者の形式になっていることがあるので、そのようなコードも読めるようにして
+implicit classはpimp my libraryパターン専用の機能であり、implicit defで既存型への変換した場合などによる混乱がないため、Scala 2.10以降でpimp my libraryパターンを使うときは基本的に後者の形式にすべきです。
+しかし、サードパーティのライブラリや標準ライブラリでも前者の形式になっていることがあるので、そのようなコードも読めるようにして
 おきましょう。
 
 ### 練習問題 {#implicit_ex1}


### PR DESCRIPTION
## 原因・やったこと

- `npm install svgexport -g` の際にoptional catch bindingを使ったファイルの処理に失敗していた
  - https://github.com/tc39/proposal-optional-catch-binding
- Nodeのバージョンを上げたところ一部node-gypの関係で動かないパッケージがあったのでそれは一緒に更新
  - `sleep`
- `package-lock.json` があるので `npm ci` の方を使用するようにした

## このPRではやらないがやった方が良さそうなこと

- package.jsonの中がだいぶ古くなっているので更新した方が良さそう
  - gitbookはメンテされてないので [honkit](https://github.com/honkit/honkit) に移行する？
- `npm install svgexport -g` はバージョンが固定されないので今回のような問題を起こしがちなのでなんとかした方が良さそう

fixes #563