### PR TITLE
警告修正

### DIFF
--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -288,7 +288,7 @@ import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
 object PromiseSample extends App {
-  val promiseGetInt: Promise[Int] = Promise[Int]
+  val promiseGetInt: Promise[Int] = Promise[Int]()
   val futureByPromise: Future[Int] = promiseGetInt.future // PromiseからFutureを作ることが出来る
 
   // Promiseが解決されたときに実行される処理をFutureを使って書くことが出来る
@@ -333,7 +333,7 @@ class FutureSomething {
   val callbackSomething = new CallbackSomething
 
   def doSomething(): Future[Int] = {
-    val promise = Promise[Int]
+    val promise = Promise[Int]()
     callbackSomething.doSomething(i => promise.success(i), t => promise.failure(t))
     promise.future
   }


### PR DESCRIPTION
```
Welcome to Scala 2.13.4 (OpenJDK 64-Bit Server VM, Java 1.8.0_275).
Type in expressions for evaluation. Or try :help.

scala> scala.concurrent.Promise[Int]
                               ^
       warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method apply,
       or remove the empty argument list from its definition (Java-defined methods are exempt).
       In Scala 3, an unapplied method like this will be eta-expanded into a function.
val res0: scala.concurrent.Promise[Int] = Future(<not completed>)

scala> scala.concurrent.Promise[Int]()
val res1: scala.concurrent.Promise[Int] = Future(<not completed>)
```