### PR TITLE
Play Frameworkの表記を変更

### DIFF
--- a/src/implicit.md
+++ b/src/implicit.md
@@ -152,7 +152,7 @@ def useDatabase3(....)(implicit conn: Connection)
 implicit val connection: Connection = connectDatabase(....)
 ```
 
-このようにすることで、最後の引数リストに暗黙に`Connection`オブジェクトを渡してくれるのです。このようなimplicit parameterの使い方はPlay 2 FrameworkやScalaの各種O/Rマッパーで頻出します。
+このようにすることで、最後の引数リストに暗黙に`Connection`オブジェクトを渡してくれるのです。このようなimplicit parameterの使い方はPlay FrameworkやScalaの各種O/Rマッパーで頻出します。
 
 implicit parameterのもう1つの使い方は、少々変わっています。まず、`List`の全ての要素の値を加算した結果を返す`sum`メソッドを定義したいとします。
 このメソッドはどのような定義になるでしょうか。ポイントは、「何の」`List`か全くわかっていないことで、整数の`+`メソッドをそのまま使ったりという


### PR DESCRIPTION
`Play 2 Framework`表記は探してみても[IntelliJのPlay 2.x 入門﻿](https://pleiades.io/help/idea/getting-started-with-play-2-x.html)ページが見つかるくらいだったので`Play Framework`または`Play Framework2`が良さそうだと思いました。