### PR TITLE
`java --version` はJDK８以下では動作しない

### DIFF
--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -30,7 +30,7 @@ https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
 $ sdk list java                 # インストールできるJavaの一覧を確認
 # sdk install java <Identifier> # <Identifier> の部分は上記のコマンドで確認した中からインストールしたいものを入れる
 $ sdk install java 11.0.15-tem  # 例
-$ java --version                # Javaがインストールされているかの確認
+$ java -version                 # Javaがインストールされているかの確認
 ```
 
 ## Mac OS, Linux, WSL（Windows） の場合


### PR DESCRIPTION
## Summary

JDK8で `java -version`をすると

```
$ java -version
openjdk version "1.8.0_345"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_345-b01)
OpenJDK 64-Bit Server VM (Temurin)(build 25.345-b01, mixed mode)

$ java --version
Unrecognized option: --version
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

のようになってしまうようなので、fix.

## Refs

- https://www.ne.jp/asahi/hishidama/home/tech/java/version.html