### PR TITLE
警告修正。getLinesに括弧付与

### DIFF
--- a/src/function.md
+++ b/src/function.md
@@ -223,7 +223,7 @@ def printFile(filename: String): Unit = ???
 ```scala mdoc:nest:silent
 def printFile(filename: String): Unit = {
   withFile(filename) { file =>
-    file.getLines.foreach(println)
+    file.getLines().foreach(println)
   }
 }
 ```


### PR DESCRIPTION
```
warning: function.md:226:5: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method getLines,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
    file.getLines.foreach(println)
    ^^^^^^^^^^^^^
```